### PR TITLE
Passing route collection through the context 

### DIFF
--- a/src/Microsoft.AspNet.Routing/RouteContext.cs
+++ b/src/Microsoft.AspNet.Routing/RouteContext.cs
@@ -20,6 +20,8 @@ namespace Microsoft.AspNet.Routing
 
         public string RequestPath { get; private set; }
 
+        public IRouter Router { get; set; }
+
         public IDictionary<string, object> Values { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Routing/RouterMiddleware.cs
+++ b/src/Microsoft.AspNet.Routing/RouterMiddleware.cs
@@ -27,7 +27,10 @@ namespace Microsoft.AspNet.Abstractions
 
         public async Task Invoke(HttpContext httpContext)
         {
-            var context = new RouteContext(httpContext);
+            var context = new RouteContext(httpContext)
+            {
+                Router = Route,
+            };
 
             await Route.RouteAsync(context);
             if (!context.IsHandled)


### PR DESCRIPTION
This lets apps get an instance of the top-level IRouter (as the middleware defines it). 
