### PR TITLE
Small refactor of TemplateBinder

### DIFF
--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
@@ -125,12 +125,23 @@ namespace Microsoft.AspNet.Routing.Template.Tests
             string expected)
         {
             // Arrange
-            var binder = new TemplateBinder(TemplateParser.Parse(template));
+            var binder = new TemplateBinder(TemplateParser.Parse(template), defaults);
 
-            // Act
-            var boundTemplate = binder.Bind(defaults, null, values);
+            // Act & Assert
+            var acceptedValues = binder.GetAcceptedValues(null, values);
+            if (acceptedValues == null)
+            {
+                if (expected == null)
+                {
+                    return;
+                }
+                else
+                {
+                    Assert.NotNull(acceptedValues);
+                }
+            }
 
-            // Assert
+            var boundTemplate = binder.BindValues(acceptedValues);
             if (expected == null)
             {
                 Assert.Null(boundTemplate);
@@ -947,12 +958,23 @@ namespace Microsoft.AspNet.Routing.Template.Tests
             string expected)
         {
             // Arrange
-            var binder = new TemplateBinder(TemplateParser.Parse(template));
+            var binder = new TemplateBinder(TemplateParser.Parse(template), defaults);
 
-            // Act
-            var boundTemplate = binder.Bind(defaults, ambientValues, values);
+            // Act & Assert
+            var acceptedValues = binder.GetAcceptedValues(ambientValues, values);
+            if (acceptedValues == null)
+            {
+                if (expected == null)
+                {
+                    return;
+                }
+                else
+                {
+                    Assert.NotNull(acceptedValues);
+                }
+            }
 
-            // Assert
+            var boundTemplate = binder.BindValues(acceptedValues);
             if (expected == null)
             {
                 Assert.Null(boundTemplate);

--- a/test/Microsoft.AspNet.Routing.Tests/project.json
+++ b/test/Microsoft.AspNet.Routing.Tests/project.json
@@ -23,7 +23,7 @@
     },
     "net45": {
       "dependencies": {
-        "Moq": "4.2.1402.2112",
+        "Moq": "4.2.1312.1622",
         "System.Runtime": ""
       }
     }


### PR DESCRIPTION
We'll need to access the accepted values to do proper link generation, so
separating this process out into 2 parts.

Also moving defaults into the TemplateBinder because they are conceptually
part of the route, not part of the request. I'll do the same for
TemplateMatcher soon, but it's a big change and worth separating.
