### PR TITLE
Fix for #77 - pass ambient values not in the template to constraints

### DIFF
--- a/src/Microsoft.AspNet.Routing/Microsoft.AspNet.Routing.kproj
+++ b/src/Microsoft.AspNet.Routing/Microsoft.AspNet.Routing.kproj
@@ -70,6 +70,7 @@
     <Compile Include="Template\TemplatePart.cs" />
     <Compile Include="Template\TemplateRoute.cs" />
     <Compile Include="Template\TemplateSegment.cs" />
+    <Compile Include="Template\TemplateValuesResult.cs" />
     <Compile Include="VirtualPathContext.cs" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/src/Microsoft.AspNet.Routing/Template/TemplateRoute.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateRoute.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNet.Routing.Template
 
         public string GetVirtualPath(VirtualPathContext context)
         {
-            var values = _binder.GetAcceptedValues(context.AmbientValues, context.Values);
+            var values = _binder.GetValues(context.AmbientValues, context.Values);
             if (values == null)
             {
                 // We're missing one of the required values for this route.
@@ -111,7 +111,7 @@ namespace Microsoft.AspNet.Routing.Template
             }
 
             if (!RouteConstraintMatcher.Match(Constraints,
-                                              values,
+                                              values.CombinedValues,
                                               context.Context,
                                               this,
                                               RouteDirection.UrlGeneration))
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.Routing.Template
             }
 
             // Validate that the target can accept these values.
-            var childContext = CreateChildVirtualPathContext(context, values);
+            var childContext = CreateChildVirtualPathContext(context, values.AcceptedValues);
             var path = _target.GetVirtualPath(childContext);
             if (path != null)
             {
@@ -134,7 +134,7 @@ namespace Microsoft.AspNet.Routing.Template
                 return null;
             }
 
-            path = _binder.BindValues(values);
+            path = _binder.BindValues(values.AcceptedValues);
             if (path != null)
             {
                 context.IsBound = true;

--- a/src/Microsoft.AspNet.Routing/Template/TemplateValuesResult.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateValuesResult.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.Routing.Template
+{
+    /// <summary>
+    /// The values used as inputs for constraints and link generation.
+    /// </summary>
+    public class TemplateValuesResult
+    {
+        /// <summary>
+        /// The set of values that will appear in the URL.
+        /// </summary>
+        public Dictionary<string, object> AcceptedValues { get; set; }
+
+        /// <summary>
+        /// The set of values that that were supplied for URL generation. 
+        /// </summary>
+        /// <remarks>
+        /// This combines implicit (ambient) values from the <see cref="RouteData"/> of the current request
+        /// (if applicable), explictly provided values, and default values for parameters that appear in
+        /// the route template.
+        /// 
+        /// Implicit (ambient) values which are invalidated due to changes in values lexically earlier in the 
+        /// route template are excluded from this set.
+        /// </remarks>
+        public Dictionary<string, object> CombinedValues { get; set; }
+    }
+}

--- a/test/Microsoft.AspNet.Routing.Tests/Microsoft.AspNet.Routing.Tests.kproj
+++ b/test/Microsoft.AspNet.Routing.Tests/Microsoft.AspNet.Routing.Tests.kproj
@@ -43,7 +43,6 @@
     <Compile Include="DefaultInlineConstraintResolverTest.cs" />
     <Compile Include="RouteCollectionTest.cs" />
     <Compile Include="InlineRouteParameterParserTests.cs" />
-    <Compile Include="DefaultValueTests.cs" />
     <Compile Include="RouteOptionsTests.cs" />
     <Compile Include="RouteValueDictionaryTests.cs" />
     <Compile Include="TemplateParserDefaultValuesTests.cs" />

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
@@ -138,8 +138,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
                                             defaults);
 
             // Act & Assert
-            var acceptedValues = binder.GetAcceptedValues(null, values);
-            if (acceptedValues == null)
+            var result = binder.GetValues(ambientValues: null, values: values);
+            if (result == null)
             {
                 if (expected == null)
                 {
@@ -147,11 +147,11 @@ namespace Microsoft.AspNet.Routing.Template.Tests
                 }
                 else
                 {
-                    Assert.NotNull(acceptedValues);
+                    Assert.NotNull(result);
                 }
             }
 
-            var boundTemplate = binder.BindValues(acceptedValues);
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
             if (expected == null)
             {
                 Assert.Null(boundTemplate);
@@ -971,8 +971,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
             var binder = new TemplateBinder(TemplateParser.Parse(template, _inlineConstraintResolver), defaults);
 
             // Act & Assert
-            var acceptedValues = binder.GetAcceptedValues(ambientValues, values);
-            if (acceptedValues == null)
+            var result = binder.GetValues(ambientValues, values);
+            if (result == null)
             {
                 if (expected == null)
                 {
@@ -980,11 +980,11 @@ namespace Microsoft.AspNet.Routing.Template.Tests
                 }
                 else
                 {
-                    Assert.NotNull(acceptedValues);
+                    Assert.NotNull(result);
                 }
             }
 
-            var boundTemplate = binder.BindValues(acceptedValues);
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
             if (expected == null)
             {
                 Assert.Null(boundTemplate);


### PR DESCRIPTION
This change adds tests and makes the behavior consistent with legacy MVC
as far as what values are visible in constraints.

This is important because it allows constraints to make decisions based on
whether or not a value is present even if it's not in the template. This
is similar to the behavior of WebAPI link generation or Area link
generation in MVC 5 - but without hardcoding.
