### PR TITLE
Implement a 'required' constraint

### DIFF
--- a/samples/RoutingSample.Web/RoutingSample.Web.kproj
+++ b/samples/RoutingSample.Web/RoutingSample.Web.kproj
@@ -20,6 +20,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
     <DevelopmentServerPort>28778</DevelopmentServerPort>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DevelopmentServerPort>22209</DevelopmentServerPort>
+  </PropertyGroup>
   <ItemGroup>
     <Content Include="project.json" />
     <Content Include="web.config" />

--- a/src/Microsoft.AspNet.Routing/Constraints/RequiredRouteConstraint.cs
+++ b/src/Microsoft.AspNet.Routing/Constraints/RequiredRouteConstraint.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.Routing.Constraints
     /// This constraint is primarily used to enforce that a non-parameter value is present during 
     /// URL generation.
     /// </remarks>
-    public class RequiredConstraint : IRouteConstraint
+    public class RequiredRouteConstraint : IRouteConstraint
     {
         /// <inheritdoc />
         public bool Match(

--- a/src/Microsoft.AspNet.Routing/Microsoft.AspNet.Routing.kproj
+++ b/src/Microsoft.AspNet.Routing/Microsoft.AspNet.Routing.kproj
@@ -41,6 +41,7 @@
     <Compile Include="Constraints\BoolRouteConstraint.cs" />
     <Compile Include="Constraints\IntRouteConstraint.cs" />
     <Compile Include="Constraints\RegexRouteConstraint.cs" />
+    <Compile Include="Constraints\RequiredRouteConstraint.cs" />
     <Compile Include="DefaultInlineConstraintResolver.cs" />
     <Compile Include="IInlineConstraintResolver.cs" />
     <Compile Include="INamedRouter.cs" />

--- a/test/Microsoft.AspNet.Routing.Tests/Constraints/RequiredRouteConstraintTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Constraints/RequiredRouteConstraintTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.Routing.Tests
         public void RequiredRouteConstraint_NoValue(RouteDirection direction)
         {
             // Arrange
-            var constraint = new RequiredConstraint();
+            var constraint = new RequiredRouteConstraint();
 
             // Act
             var result = constraint.Match(
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.Routing.Tests
         public void RequiredRouteConstraint_Null(RouteDirection direction)
         {
             // Arrange
-            var constraint = new RequiredConstraint();
+            var constraint = new RequiredRouteConstraint();
 
             // Act
             var result = constraint.Match(
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.Routing.Tests
         public void RequiredRouteConstraint_EmptyString(RouteDirection direction)
         {
             // Arrange
-            var constraint = new RequiredConstraint();
+            var constraint = new RequiredRouteConstraint();
 
             // Act
             var result = constraint.Match(
@@ -79,7 +79,7 @@ namespace Microsoft.AspNet.Routing.Tests
         public void RequiredRouteConstraint_WithValue(RouteDirection direction)
         {
             // Arrange
-            var constraint = new RequiredConstraint();
+            var constraint = new RequiredRouteConstraint();
 
             // Act
             var result = constraint.Match(

--- a/test/Microsoft.AspNet.Routing.Tests/Microsoft.AspNet.Routing.Tests.kproj
+++ b/test/Microsoft.AspNet.Routing.Tests/Microsoft.AspNet.Routing.Tests.kproj
@@ -40,10 +40,10 @@
     <Compile Include="Constraints\AlphaRouteConstraintTests.cs" />
     <Compile Include="Constraints\RegexConstraintTests.cs" />
     <Compile Include="Constraints\IntRouteConstraintsTests.cs" />
+    <Compile Include="Constraints\RequiredRouteConstraintTests.cs" />
     <Compile Include="DefaultInlineConstraintResolverTest.cs" />
     <Compile Include="RouteCollectionTest.cs" />
     <Compile Include="InlineRouteParameterParserTests.cs" />
-    <Compile Include="DefaultValueTests.cs" />
     <Compile Include="RouteOptionsTests.cs" />
     <Compile Include="RouteValueDictionaryTests.cs" />
     <Compile Include="TemplateParserDefaultValuesTests.cs" />


### PR DESCRIPTION
This is useful for a variety of interesting scenarios in link generation
where a default value doesn't appear in the route template as a parameter.

This can be used to implement the desired behavior for areas - where the
'area' key is sticky.
