### PR TITLE
Fix for #104 - RouterMiddleware should take ILoggerFactory in the

### DIFF
--- a/test/Microsoft.AspNet.Routing.Tests/project.json
+++ b/test/Microsoft.AspNet.Routing.Tests/project.json
@@ -3,6 +3,7 @@
         "warningsAsErrors": "true"
     },
     "dependencies": {
+        "Microsoft.AspNet.PipelineCore": "1.0.0-*",
         "Microsoft.AspNet.Routing": "1.0.0-*",
         "Microsoft.AspNet.Testing": "1.0.0-*",
         "Xunit.KRunner": "1.0.0-*"


### PR DESCRIPTION
constructor

Did some cleanup here to make these tests work on CoreCLR. They weren't
using Moq for anything important.
