### PR TITLE
Basic URL Extension functionality working.

### DIFF
--- a/src/Microsoft.AspNet.Routing/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Routing/Properties/Resources.Designer.cs
@@ -205,17 +205,17 @@ namespace Microsoft.AspNet.Routing
         /// <summary>
         /// A path segment that contains more than one section, such as a literal section or a parameter, cannot contain an optional parameter.
         /// </summary>
-        internal static string TemplateRoute_CannotHaveOptionalParameterInMultiSegment
+        internal static string TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator
         {
-            get { return GetString("TemplateRoute_CannotHaveOptionalParameterInMultiSegment"); }
+            get { return GetString("TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator"); }
         }
 
         /// <summary>
         /// A path segment that contains more than one section, such as a literal section or a parameter, cannot contain an optional parameter.
         /// </summary>
-        internal static string FormatTemplateRoute_CannotHaveOptionalParameterInMultiSegment()
+        internal static string FormatTemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator()
         {
-            return GetString("TemplateRoute_CannotHaveOptionalParameterInMultiSegment");
+            return GetString("TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator");
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Routing/Resources.resx
+++ b/src/Microsoft.AspNet.Routing/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -153,8 +153,8 @@
   <data name="TemplateRoute_CannotHaveConsecutiveSeparators" xml:space="preserve">
     <value>The route template separator character '/' cannot appear consecutively. It must be separated by either a parameter or a literal value.</value>
   </data>
-  <data name="TemplateRoute_CannotHaveOptionalParameterInMultiSegment" xml:space="preserve">
-    <value>A path segment that contains more than one section, such as a literal section or a parameter, cannot contain an optional parameter.</value>
+  <data name="TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator" xml:space="preserve">
+    <value>In a path segment that contains more than one section, such as a literal section or a parameter, there can only be one optional parameter. The optional parameter must be the last parameter in the segment and must be preceded by one single period (.).</value>
   </data>
   <data name="TemplateRoute_CatchAllCannotBeOptional" xml:space="preserve">
     <value>A catch-all parameter cannot be marked optional.</value>

--- a/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
@@ -220,14 +220,21 @@ namespace Microsoft.AspNet.Routing.Template
                             // we won't necessarily add it to the URI we generate.
                             if (!context.Buffer(converted))
                             {
-                                return null;
+                                    return null;
                             }
                         }
                         else
                         {
                             if (!context.Accept(converted))
                             {
-                                return null;
+                                if (part.IsOptional && segment.Parts[j - 1].IsOptionalSeperator)
+                                {
+                                    context.Remove(segment.Parts[j - 1].Text);
+                                }
+                                else
+                                {
+                                    return null;
+                                }
                             }
                         }
                     }
@@ -470,6 +477,12 @@ namespace Microsoft.AspNet.Routing.Template
 
                 _uri.Append(value);
                 return true;
+            }
+
+            public void Remove(string literal)
+            {
+                int startIndex = _uri.Length - literal.Length;
+                _uri.Remove(startIndex, literal.Length);
             }
 
             public bool Buffer(string value)

--- a/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.AspNet.WebUtilities;
+using Microsoft.AspNet.Http.Extensions;
 
 namespace Microsoft.AspNet.Routing.Template
 {
@@ -225,9 +226,17 @@ namespace Microsoft.AspNet.Routing.Template
                         }
                         else
                         {
+                            // If the value is not accepted, it is null or empty value in the 
+                            // middle of the segment. We accept this if the parameter is an
+                            // optional parameter and it is preceded by an optional seperator.
+                            // I this case, we need to remove the optional seperator that we
+                            // have added to the URI
+                            // Example: template = {id}.{format?}. parameters: id=5
+                            // In this case after we have generated "5.", we wont find any value 
+                            // for format, so we remove '.' and generate 5.
                             if (!context.Accept(converted))
                             {
-                                if (part.IsOptional && segment.Parts[j - 1].IsOptionalSeperator)
+                                if (j != 0 && part.IsOptional && segment.Parts[j - 1].IsOptionalSeperator)
                                 {
                                     context.Remove(segment.Parts[j - 1].Text);
                                 }
@@ -481,8 +490,7 @@ namespace Microsoft.AspNet.Routing.Template
 
             public void Remove(string literal)
             {
-                int startIndex = _uri.Length - literal.Length;
-                _uri.Remove(startIndex, literal.Length);
+                _uri.Length -= literal.Length;
             }
 
             public bool Buffer(string value)

--- a/src/Microsoft.AspNet.Routing/Template/TemplateMatcher.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateMatcher.cs
@@ -170,8 +170,18 @@ namespace Microsoft.AspNet.Routing.Template
                                          RouteValueDictionary values)
         {
             var indexOfLastSegment = routeSegment.Parts.Count - 1;
-            if(routeSegment.Parts[indexOfLastSegment].IsOptional && 
-                routeSegment.Parts[indexOfLastSegment - 1].IsOptionalSeperator)
+
+            // We match the request to the template starting at the rightmost parameter
+            // If the last segment of template is optional, then request can match the 
+            // template with or without the last parameter. So we start with regular matching,
+            // but if it doesn't match, we start with next to last parameter. Example:
+            // Template: {p1}/{p2}.{p3?}. If the request is foo/bar.moo it will match right away
+            // giving p3 value of moo. But if the request is foo/bar, we start matching from the
+            // rightmost giving p3 the value of bar, then we end up not matching the segment.
+            // In this case we start again from p2 to match the request and we succeed giving
+            // the value bar to p2
+            if (routeSegment.Parts[indexOfLastSegment].IsOptional &&
+                routeSegment.Parts[indexOfLastSegment - 1].IsOptionalSeperator)            
             {
                 if (MatchComplexSegmentCore(routeSegment, requestSegment, Defaults, values, indexOfLastSegment))
                 {
@@ -179,16 +189,16 @@ namespace Microsoft.AspNet.Routing.Template
                 }
                 else
                 {
-                    if(requestSegment.EndsWith(routeSegment.Parts[indexOfLastSegment-1].Text))
+                    if (requestSegment.EndsWith(routeSegment.Parts[indexOfLastSegment - 1].Text))
                     {
                         return false;
                     }
-                    
+
                     return MatchComplexSegmentCore(
-                        routeSegment, 
-                        requestSegment, 
-                        Defaults, 
-                        values, 
+                        routeSegment,
+                        requestSegment,
+                        Defaults,
+                        values,
                         indexOfLastSegment - 2);
                 }
             }
@@ -209,8 +219,7 @@ namespace Microsoft.AspNet.Routing.Template
 
             // Find last literal segment and get its last index in the string
             var lastIndex = requestSegment.Length;
-            //var indexOfLastSegmentUsed = routeSegment.Parts.Count - 1;
-
+            
             TemplatePart parameterNeedsValue = null; // Keeps track of a parameter segment that is pending a value
             TemplatePart lastLiteral = null; // Keeps track of the left-most literal we've encountered
 

--- a/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
@@ -16,6 +16,7 @@ namespace Microsoft.AspNet.Routing.Template
         private const char EqualsSign = '=';
         private const char QuestionMark = '?';
         private const char Asterisk = '*';
+        private const string PeriodString = ".";
 
         public static RouteTemplate Parse(string routeTemplate)
         {
@@ -322,10 +323,27 @@ namespace Microsoft.AspNet.Routing.Template
             for (var i = 0; i < segment.Parts.Count; i++)
             {
                 var part = segment.Parts[i];
+                
                 if (part.IsParameter && part.IsOptional && segment.Parts.Count > 1)
                 {
-                    context.Error = Resources.TemplateRoute_CannotHaveOptionalParameterInMultiSegment;
-                    return false;
+                    // This is the last part
+                    if (i == segment.Parts.Count - 1)
+                    {
+                        if(segment.Parts[i-1].Text == PeriodString)
+                        {
+                            part.IsFollowingAPeriod = true;
+                        }
+                        else
+                        {
+                            context.Error = Resources.TemplateRoute_CannotHaveOptionalParameterInMultiSegment;
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        context.Error = Resources.TemplateRoute_CannotHaveOptionalParameterInMultiSegment;
+                        return false;
+                    }
                 }
             }
 

--- a/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
@@ -319,35 +319,40 @@ namespace Microsoft.AspNet.Routing.Template
                 }
             }
 
-            // if a segment has multiple parts, then the parameters can't be optional
+            // if a segment has multiple parts, then only the last one parameter can be optional 
+            // if it is following a optional seperator. 
             for (var i = 0; i < segment.Parts.Count; i++)
             {
                 var part = segment.Parts[i];
-                
+
                 if (part.IsParameter && part.IsOptional && segment.Parts.Count > 1)
                 {
                     // This is the last part
                     if (i == segment.Parts.Count - 1)
                     {
-                        if(segment.Parts[i-1].Text == PeriodString)
+                        Debug.Assert(segment.Parts[i - 1].IsLiteral);
+
+                        if (segment.Parts[i - 1].Text == PeriodString)
                         {
-                            part.IsFollowingAPeriod = true;
+                            segment.Parts[i - 1].IsOptionalSeperator = true;
                         }
                         else
                         {
-                            context.Error = Resources.TemplateRoute_CannotHaveOptionalParameterInMultiSegment;
+                            context.Error = 
+                                Resources.TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator;
                             return false;
                         }
                     }
                     else
                     {
-                        context.Error = Resources.TemplateRoute_CannotHaveOptionalParameterInMultiSegment;
+                        context.Error = 
+                            Resources.TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator;
                         return false;
                     }
                 }
             }
 
-            // A segment cannot containt two consecutive parameters
+            // A segment cannot contain two consecutive parameters
             var isLastSegmentParameter = false;
             for (var i = 0; i < segment.Parts.Count; i++)
             {

--- a/src/Microsoft.AspNet.Routing/Template/TemplatePart.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplatePart.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNet.Routing.Template
         public bool IsLiteral { get; private set; }
         public bool IsParameter { get; private set; }
         public bool IsOptional { get; private set; }
-        public bool IsFollowingAPeriod { get; set; }
+        public bool IsOptionalSeperator { get; set; }
         public string Name { get; private set; }
         public string Text { get; private set; }
         public object DefaultValue { get; private set; }

--- a/src/Microsoft.AspNet.Routing/Template/TemplatePart.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplatePart.cs
@@ -40,6 +40,7 @@ namespace Microsoft.AspNet.Routing.Template
         public bool IsLiteral { get; private set; }
         public bool IsParameter { get; private set; }
         public bool IsOptional { get; private set; }
+        public bool IsFollowingAPeriod { get; set; }
         public string Name { get; private set; }
         public string Text { get; private set; }
         public object DefaultValue { get; private set; }

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
@@ -197,6 +197,131 @@ namespace Microsoft.AspNet.Routing.Template.Tests
                 "language/axx-yy");
         }
 
+        public static IEnumerable<object[]> OptionalParamValues
+        {
+            get
+            {
+                return new object[][]
+                {
+                    // defaults
+                    // ambient values
+                    // values
+                    new object[]
+                    {
+                        "Test/{val1}/{val2}.{val3?}",
+                        new RouteValueDictionary(new {val1 = "someval1", val2 = "someval2"}),
+                        new RouteValueDictionary(new {val3 = "someval3"}),
+                        new RouteValueDictionary(new {val3 = "someval3"}),
+                        "Test/someval1/someval2.someval3",
+                    },
+                    new object[]
+                    {
+                        "Test/{val1}/{val2}.{val3?}",
+                        new RouteValueDictionary(new {val1 = "someval1", val2 = "someval2"}),
+                        new RouteValueDictionary(new {val3 = "someval3a"}),
+                        new RouteValueDictionary(new {val3 = "someval3v"}),
+                        "Test/someval1/someval2.someval3v",
+                    },
+                    new object[]
+                    {
+                        "Test/{val1}/{val2}.{val3?}",
+                        new RouteValueDictionary(new {val1 = "someval1", val2 = "someval2"}),
+                        new RouteValueDictionary(new {val3 = "someval3a"}),
+                        new RouteValueDictionary(),
+                        "Test/someval1/someval2.someval3a",
+                    },                    
+                    new object[]
+                    {
+                        "Test/{val1}/{val2}.{val3?}",
+                        new RouteValueDictionary(new {val1 = "someval1", val2 = "someval2"}),
+                        new RouteValueDictionary(),
+                        new RouteValueDictionary(new {val3 = "someval3v"}),
+                        "Test/someval1/someval2.someval3v",
+                    },
+                    new object[]
+                    {
+                        "Test/{val1}/{val2}.{val3?}",
+                        new RouteValueDictionary(new {val1 = "someval1", val2 = "someval2"}),
+                        new RouteValueDictionary(),
+                        new RouteValueDictionary(),
+                        "Test/someval1/someval2",
+                    },                    
+                    new object[]
+                    {
+                        "Test/{val1}.{val2}.{val3}.{val4?}",
+                        new RouteValueDictionary(new {val1 = "someval1", val2 = "someval2" }),
+                        new RouteValueDictionary(),
+                        new RouteValueDictionary(new {val4 = "someval4", val3 = "someval3" }),
+                        "Test/someval1.someval2.someval3.someval4",
+                    },
+                    new object[]
+                    {
+                        "Test/{val1}.{val2}.{val3}.{val4?}",
+                        new RouteValueDictionary(new {val1 = "someval1", val2 = "someval2" }),
+                        new RouteValueDictionary(),
+                        new RouteValueDictionary(new {val3 = "someval3" }),
+                        "Test/someval1.someval2.someval3",
+                    },
+                    new object[]
+                    {
+                        "Test/.{val2?}",
+                        new RouteValueDictionary(new { }),
+                        new RouteValueDictionary(),
+                        new RouteValueDictionary(new {val2 = "someval2" }),
+                        "Test/.someval2",
+                    },
+                    new object[]
+                    {
+                        "Test/{val1}.{val2}",
+                        new RouteValueDictionary(new {val1 = "someval1", val2 = "someval2" }),
+                        new RouteValueDictionary(),
+                        new RouteValueDictionary(new {val3 = "someval3" }),
+                        "Test/someval1.someval2?val3=someval3",
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData("OptionalParamValues")]
+        public void GetVirtualPathWithMultiSegmentWithOptionalParam(
+            string template,
+            IReadOnlyDictionary<string, object> defaults,
+            IDictionary<string, object> ambientValues,
+            IDictionary<string, object> values,
+            string expected)
+        {
+            // Arrange
+            var binder = new TemplateBinder(
+                TemplateParser.Parse(template),
+                defaults);
+
+            // Act & Assert
+            var result = binder.GetValues(ambientValues: ambientValues, values: values);
+            if (result == null)
+            {
+                if (expected == null)
+                {
+                    return;
+                }
+                else
+                {
+                    Assert.NotNull(result);
+                }
+            }
+
+            var boundTemplate = binder.BindValues(result.AcceptedValues);
+            if (expected == null)
+            {
+                Assert.Null(boundTemplate);
+            }
+            else
+            {
+                Assert.NotNull(boundTemplate);
+                Assert.Equal(expected, boundTemplate);
+            }
+        }
+        
         [Fact]
         public void GetVirtualPathWithMultiSegmentParamsOnNeitherEndMatches()
         {

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateMatcherTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateMatcherTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         }
 
         [Theory]
-        [InlineData("moo/{p1}.{p2?}", "moo/foo.bar", "foo", "bar")]
+        [InlineData("moo/{p1}.{p2?}", "moo/foo.bar", "foo", "bar")]        
         [InlineData("moo/{p1?}", "moo/foo", "foo", null)]
         [InlineData("moo/{p1?}", "moo", null, null)]
         [InlineData("moo/{p1}.{p2?}", "moo/foo", "foo", null)]
@@ -111,6 +111,10 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         [InlineData("moo/{p1}.{p2}", "moo/foo.bar", "foo", "bar")]
         [InlineData("moo/foo.{p1}.{p2?}", "moo/foo.moo.bar", "moo", "bar")]
         [InlineData("moo/foo.{p1}.{p2?}", "moo/foo.moo", "moo", null)]
+        [InlineData("moo/.{p2?}", "moo/.foo", null, "foo")]
+        [InlineData("moo/.{p2?}", "moo", null, null)]
+        [InlineData("moo/{p1}.{p2?}", "moo/....", "..", ".")]
+        [InlineData("moo/{p1}.{p2?}", "moo/.bar", ".bar", null)]
         public void MatchRoute_OptionalParameter_FollowedByPeriod_Valid(
             string template, 
             string path, 
@@ -139,7 +143,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         [InlineData("moo/{p1}.{p2}.{p3?}", "moo/foo.moo", "foo", "moo", null)]
         [InlineData("moo/{p1}.{p2}.{p3}.{p4?}", "moo/foo.moo.bar", "foo", "moo", "bar")]
         [InlineData("{p1}.{p2?}/{p3}", "foo.moo/bar", "foo", "moo", "bar")]
-        [InlineData("{p1}.{p2?}/{p3}", "foo/bar", "foo", null, "bar")]
+        [InlineData("{p1}.{p2?}/{p3}", "foo/bar", "foo", null, "bar")]        
+        [InlineData("{p1}.{p2?}/{p3}", ".foo/bar", ".foo", null, "bar")]
         public void MatchRoute_OptionalParameter_FollowedByPeriod_3Parameters_Valid(
             string template, 
             string path, 
@@ -170,9 +175,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
 
         [Theory]        
         [InlineData("moo/{p1}.{p2?}", "moo/foo.")]
-        [InlineData("moo/{p1}.{p2?}", "moo/.")]
-        [InlineData("moo/{p1}.{p2?}", "moo/.bar")]
-        [InlineData("moo/{p1}.{p2?}", "moo/....")]
+        [InlineData("moo/{p1}.{p2?}", "moo/.")]        
         [InlineData("moo/{p1}.{p2}", "foo.")]
         [InlineData("moo/{p1}.{p2}", "foo")]
         [InlineData("moo/{p1}.{p2}.{p3?}", "moo/foo.moo.")]
@@ -180,8 +183,9 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         [InlineData("moo/foo.{p2}.{p3?}", "moo/kungfoo.moo.bar")]
         [InlineData("moo/foo.{p2}.{p3?}", "moo/kungfoo.moo")]
         [InlineData("moo/{p1}.{p2}.{p3?}", "moo/foo")]
-        [InlineData("{p1}.{p2?}/{p3}", "foo./bar")]
-        [InlineData("{p1}.{p2?}/{p3}", ".foo/bar")]
+        [InlineData("{p1}.{p2?}/{p3}", "foo./bar")]        
+        [InlineData("moo/.{p2?}", "moo/.")]
+        [InlineData("{p1}.{p2}/{p3}", ".foo/bar")]
         public void MatchRoute_OptionalParameter_FollowedByPeriod_Invalid(string template, string path)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateMatcherTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateMatcherTests.cs
@@ -101,6 +101,99 @@ namespace Microsoft.AspNet.Routing.Template.Tests
             Assert.Equal("default p2", rd["p2"]);
         }
 
+        [Theory]
+        [InlineData("moo/{p1}.{p2?}", "moo/foo.bar", "foo", "bar")]
+        [InlineData("moo/{p1?}", "moo/foo", "foo", null)]
+        [InlineData("moo/{p1?}", "moo", null, null)]
+        [InlineData("moo/{p1}.{p2?}", "moo/foo", "foo", null)]
+        [InlineData("moo/{p1}.{p2?}", "moo/foo..bar", "foo.", "bar")]
+        [InlineData("moo/{p1}.{p2?}", "moo/foo.moo.bar", "foo.moo", "bar")]
+        [InlineData("moo/{p1}.{p2}", "moo/foo.bar", "foo", "bar")]
+        [InlineData("moo/foo.{p1}.{p2?}", "moo/foo.moo.bar", "moo", "bar")]
+        [InlineData("moo/foo.{p1}.{p2?}", "moo/foo.moo", "moo", null)]
+        public void MatchRoute_OptionalParameter_FollowedByPeriod_Valid(
+            string template, 
+            string path, 
+            string p1, 
+            string p2)
+        {
+            // Arrange
+            var matcher = CreateMatcher(template);
+
+            // Act
+            var rd = matcher.Match(path);
+
+            // Assert
+            if (p1 != null)
+            {
+                Assert.Equal(p1, rd["p1"]);
+            }
+            if (p2 != null)
+            {
+                Assert.Equal(p2, rd["p2"]);
+            }
+        }
+
+        [Theory]
+        [InlineData("moo/{p1}.{p2}.{p3?}", "moo/foo.moo.bar", "foo", "moo", "bar")]
+        [InlineData("moo/{p1}.{p2}.{p3?}", "moo/foo.moo", "foo", "moo", null)]
+        [InlineData("moo/{p1}.{p2}.{p3}.{p4?}", "moo/foo.moo.bar", "foo", "moo", "bar")]
+        [InlineData("{p1}.{p2?}/{p3}", "foo.moo/bar", "foo", "moo", "bar")]
+        [InlineData("{p1}.{p2?}/{p3}", "foo/bar", "foo", null, "bar")]
+        public void MatchRoute_OptionalParameter_FollowedByPeriod_3Parameters_Valid(
+            string template, 
+            string path, 
+            string p1, 
+            string p2, 
+            string p3)
+        {
+            // Arrange
+            var matcher = CreateMatcher(template);
+
+            // Act
+            var rd = matcher.Match(path);
+
+            // Assert
+            
+            Assert.Equal(p1, rd["p1"]);
+            
+            if (p2 != null)
+            {
+                Assert.Equal(p2, rd["p2"]);
+            }
+
+            if (p3 != null)
+            {
+                Assert.Equal(p3, rd["p3"]);
+            }
+        }
+
+        [Theory]        
+        [InlineData("moo/{p1}.{p2?}", "moo/foo.")]
+        [InlineData("moo/{p1}.{p2?}", "moo/.")]
+        [InlineData("moo/{p1}.{p2?}", "moo/.bar")]
+        [InlineData("moo/{p1}.{p2?}", "moo/....")]
+        [InlineData("moo/{p1}.{p2}", "foo.")]
+        [InlineData("moo/{p1}.{p2}", "foo")]
+        [InlineData("moo/{p1}.{p2}.{p3?}", "moo/foo.moo.")]
+        [InlineData("moo/foo.{p2}.{p3?}", "moo/bar.foo.moo")]
+        [InlineData("moo/foo.{p2}.{p3?}", "moo/kungfoo.moo.bar")]
+        [InlineData("moo/foo.{p2}.{p3?}", "moo/kungfoo.moo")]
+        [InlineData("moo/{p1}.{p2}.{p3?}", "moo/foo")]
+        [InlineData("{p1}.{p2?}/{p3}", "foo./bar")]
+        [InlineData("{p1}.{p2?}/{p3}", ".foo/bar")]
+        public void MatchRoute_OptionalParameter_FollowedByPeriod_Invalid(string template, string path)
+        {
+            // Arrange
+            var matcher = CreateMatcher(template);
+
+            // Act
+            var rd = matcher.Match(path);
+
+            // Assert
+            Assert.Null(rd);
+        }
+
         [Fact]
         public void MatchRouteWithOnlyLiterals()
         {
@@ -183,7 +276,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
             // Assert
             Assert.Null(rd);
         }
-
+        
         [Fact]
         public void NoMatchLongerUrl()
         {

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateParserTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateParserTests.cs
@@ -228,6 +228,231 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         }
 
         [Fact]
+        public void Parse_ComplexSegment_OptionalParameterFollowingPeriod()
+        {
+            // Arrange
+            var template = "{p1}.{p2?}";
+
+            var expected = new RouteTemplate(new List<TemplateSegment>());
+            expected.Segments.Add(new TemplateSegment());
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p1",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateLiteral("."));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p2",
+                                                                        false,
+                                                                        true,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+
+            expected.Parameters.Add(expected.Segments[0].Parts[0]);
+            expected.Parameters.Add(expected.Segments[0].Parts[2]);
+
+            // Act
+            var actual = TemplateParser.Parse(template);
+
+            // Assert
+            Assert.Equal<RouteTemplate>(expected, actual, new TemplateEqualityComparer());
+        }
+
+        [Fact]
+        public void Parse_ComplexSegment_ParametersFollowingPeriod()
+        {
+            // Arrange
+            var template = "{p1}.{p2}";
+
+            var expected = new RouteTemplate(new List<TemplateSegment>());
+            expected.Segments.Add(new TemplateSegment());
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p1",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateLiteral("."));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p2",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+
+            expected.Parameters.Add(expected.Segments[0].Parts[0]);
+            expected.Parameters.Add(expected.Segments[0].Parts[2]);
+
+            // Act
+            var actual = TemplateParser.Parse(template);
+
+            // Assert
+            Assert.Equal<RouteTemplate>(expected, actual, new TemplateEqualityComparer());
+        }
+
+        [Fact]
+        public void Parse_ComplexSegment_OptionalParameterFollowingPeriod_Threeparameters()
+        {
+            // Arrange
+            var template = "{p1}.{p2}.{p3?}";
+
+            var expected = new RouteTemplate(new List<TemplateSegment>());
+            expected.Segments.Add(new TemplateSegment());
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p1",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateLiteral("."));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p2",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+
+            expected.Segments[0].Parts.Add(TemplatePart.CreateLiteral("."));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p3",
+                                                                        false,
+                                                                        true,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+
+
+            expected.Parameters.Add(expected.Segments[0].Parts[0]);
+            expected.Parameters.Add(expected.Segments[0].Parts[2]);
+            expected.Parameters.Add(expected.Segments[0].Parts[4]);
+
+            // Act
+            var actual = TemplateParser.Parse(template);
+
+            // Assert
+            Assert.Equal<RouteTemplate>(expected, actual, new TemplateEqualityComparer());
+        }
+
+        [Fact]
+        public void Parse_ComplexSegment_ThreeparametersSeperatedByPeriod()
+        {
+            // Arrange
+            var template = "{p1}.{p2}.{p3}";
+
+            var expected = new RouteTemplate(new List<TemplateSegment>());
+            expected.Segments.Add(new TemplateSegment());
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p1",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateLiteral("."));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p2",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+
+            expected.Segments[0].Parts.Add(TemplatePart.CreateLiteral("."));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p3",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+
+
+            expected.Parameters.Add(expected.Segments[0].Parts[0]);
+            expected.Parameters.Add(expected.Segments[0].Parts[2]);
+            expected.Parameters.Add(expected.Segments[0].Parts[4]);
+
+            // Act
+            var actual = TemplateParser.Parse(template);
+
+            // Assert
+            Assert.Equal<RouteTemplate>(expected, actual, new TemplateEqualityComparer());
+        }
+
+        [Fact]
+        public void Parse_ComplexSegment_OptionalParameterFollowingPeriod_MiddleSegment()
+        {
+            // Arrange
+            var template = "{p1}.{p2?}/{p3}";
+
+            var expected = new RouteTemplate(new List<TemplateSegment>());
+            expected.Segments.Add(new TemplateSegment());
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p1",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateLiteral("."));
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p2",
+                                                                        false,
+                                                                        true,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+
+            expected.Parameters.Add(expected.Segments[0].Parts[0]);
+            expected.Parameters.Add(expected.Segments[0].Parts[2]);
+
+            expected.Segments.Add(new TemplateSegment());
+            expected.Segments[1].Parts.Add(TemplatePart.CreateParameter("p3",
+                                                                        false,
+                                                                        false,
+                                                                        null,
+                                                                        null));
+            expected.Parameters.Add(expected.Segments[1].Parts[0]);
+            // Act
+            var actual = TemplateParser.Parse(template);
+
+            // Assert
+            Assert.Equal<RouteTemplate>(expected, actual, new TemplateEqualityComparer());
+        }
+
+        public void Parse_ComplexSegment_OptionalParameterFollowingPeriod_LastSegment()
+        {
+            // Arrange
+            var template = "{p1}/{p2}.{p3?}";
+
+            var expected = new RouteTemplate(new List<TemplateSegment>());
+            expected.Segments.Add(new TemplateSegment());
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p1",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+
+            expected.Segments.Add(new TemplateSegment());            
+            expected.Segments[1].Parts.Add(TemplatePart.CreateParameter("p2",
+                                                                        false,
+                                                                        true,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+            expected.Segments[1].Parts.Add(TemplatePart.CreateLiteral("."));
+            expected.Segments[1].Parts.Add(TemplatePart.CreateParameter("p3",
+                                                                        false,
+                                                                        true,
+                                                                        null,
+                                                                        null));
+            expected.Parameters.Add(expected.Segments[0].Parts[0]);
+            expected.Parameters.Add(expected.Segments[1].Parts[0]);
+            expected.Parameters.Add(expected.Segments[1].Parts[2]);
+            
+            // Act
+            var actual = TemplateParser.Parse(template);
+
+            // Assert
+            Assert.Equal<RouteTemplate>(expected, actual, new TemplateEqualityComparer());
+        }
+
+        [Theory]        
+        [InlineData("{p1?}.{p2?}")]
+        [InlineData("{p1}.{p2?}.{p3}")]
+        [InlineData("{p1?}.{p2}/{p3}")]
+        [InlineData("{p3}.{p1?}.{p2?}")]
+        [InlineData("{p1}-{p2?}")]
+        [InlineData("{p1}..{p2?}")]
+        [InlineData("{p1}.abc.{p2?}")]
+        public void Parse_ComplexSegment_OptionalParametersSeperatedByPeriod_Invalid(string template)
+        {
+            // Act and Assert
+            Assert.Throws<ArgumentException>(() => TemplateParser.Parse(template));
+        }
+        
+        [Fact]
         public void InvalidTemplate_WithRepeatedParameter()
         {
             var ex = ExceptionAssert.Throws<ArgumentException>(

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateParserTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateParserTests.cs
@@ -40,7 +40,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
 
             var expected = new RouteTemplate(new List<TemplateSegment>());
             expected.Segments.Add(new TemplateSegment());
-            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p", false, false, defaultValue: null, inlineConstraints: null));
+            expected.Segments[0].Parts.Add(
+                TemplatePart.CreateParameter("p", false, false, defaultValue: null, inlineConstraints: null));
             expected.Parameters.Add(expected.Segments[0].Parts[0]);
 
             // Act
@@ -58,7 +59,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
 
             var expected = new RouteTemplate(new List<TemplateSegment>());
             expected.Segments.Add(new TemplateSegment());
-            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p", false, true, defaultValue: null, inlineConstraints: null));
+            expected.Segments[0].Parts.Add(
+                TemplatePart.CreateParameter("p", false, true, defaultValue: null, inlineConstraints: null));
             expected.Parameters.Add(expected.Segments[0].Parts[0]);
 
             // Act
@@ -288,7 +290,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         }
 
         [Fact]
-        public void Parse_ComplexSegment_OptionalParameterFollowingPeriod_Threeparameters()
+        public void Parse_ComplexSegment_OptionalParameterFollowingPeriod_ThreeParameters()
         {
             // Arrange
             var template = "{p1}.{p2}.{p3?}";
@@ -327,7 +329,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         }
 
         [Fact]
-        public void Parse_ComplexSegment_ThreeparametersSeperatedByPeriod()
+        public void Parse_ComplexSegment_ThreeParametersSeperatedByPeriod()
         {
             // Arrange
             var template = "{p1}.{p2}.{p3}";
@@ -438,6 +440,37 @@ namespace Microsoft.AspNet.Routing.Template.Tests
             Assert.Equal<RouteTemplate>(expected, actual, new TemplateEqualityComparer());
         }
 
+        [Fact]
+        public void Parse_ComplexSegment_OptionalParameterFollowingPeriod_PeriodAfterSlash()
+        {
+            // Arrange
+            var template = "{p2}/.{p3?}";
+
+            var expected = new RouteTemplate(new List<TemplateSegment>());
+            expected.Segments.Add(new TemplateSegment());
+            expected.Segments[0].Parts.Add(TemplatePart.CreateParameter("p2",
+                                                                        false,
+                                                                        false,
+                                                                        defaultValue: null,
+                                                                        inlineConstraints: null));
+
+            expected.Segments.Add(new TemplateSegment());
+            expected.Segments[1].Parts.Add(TemplatePart.CreateLiteral("."));
+            expected.Segments[1].Parts.Add(TemplatePart.CreateParameter("p3",
+                                                                        false,
+                                                                        true,
+                                                                        null,
+                                                                        null));
+            expected.Parameters.Add(expected.Segments[0].Parts[0]);
+            expected.Parameters.Add(expected.Segments[1].Parts[1]);            
+
+            // Act
+            var actual = TemplateParser.Parse(template);
+
+            // Assert
+            Assert.Equal<RouteTemplate>(expected, actual, new TemplateEqualityComparer());
+        }
+
         [Theory]        
         [InlineData("{p1?}.{p2?}")]
         [InlineData("{p1}.{p2?}.{p3}")]
@@ -445,11 +478,17 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         [InlineData("{p3}.{p1?}.{p2?}")]
         [InlineData("{p1}-{p2?}")]
         [InlineData("{p1}..{p2?}")]
+        [InlineData("..{p2?}")]
         [InlineData("{p1}.abc.{p2?}")]
         public void Parse_ComplexSegment_OptionalParametersSeperatedByPeriod_Invalid(string template)
         {
             // Act and Assert
-            Assert.Throws<ArgumentException>(() => TemplateParser.Parse(template));
+            ExceptionAssert.Throws<ArgumentException>(
+                () => TemplateParser.Parse(template),
+                "In a path segment that contains more than one section, such as a literal section or a parameter, " + 
+                "there can only be one optional parameter. The optional parameter must be the last parameter in the " +
+                "segment and must be preceded by one single period (.)." + Environment.NewLine +
+                "Parameter name: routeTemplate");
         }
         
         [Fact]
@@ -457,7 +496,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             var ex = ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("{Controller}.mvc/{id}/{controller}"),
-                "The route parameter name 'controller' appears more than one time in the route template." + Environment.NewLine + "Parameter name: routeTemplate");
+                "The route parameter name 'controller' appears more than one time in the route template." + 
+                Environment.NewLine + "Parameter name: routeTemplate");
         }
 
         [Theory]
@@ -471,7 +511,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse(template),
-                @"There is an incomplete parameter in the route template. Check that each '{' character has a matching '}' character." + Environment.NewLine +
+                @"There is an incomplete parameter in the route template. Check that each '{' character has a " +
+                "matching '}' character." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -480,7 +521,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("123{a}abc{*moo}"),
-                "A path segment that contains more than one section, such as a literal section or a parameter, cannot contain a catch-all parameter." + Environment.NewLine +
+                "A path segment that contains more than one section, such as a literal section or a parameter, " + 
+                "cannot contain a catch-all parameter." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -489,7 +531,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("{*p1}/{*p2}"),
-                "A catch-all parameter can only appear as the last segment of the route template." + Environment.NewLine +
+                "A catch-all parameter can only appear as the last segment of the route template." + 
+                Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -498,7 +541,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("{*p1}abc{*p2}"),
-                "A path segment that contains more than one section, such as a literal section or a parameter, cannot contain a catch-all parameter." + Environment.NewLine +
+                "A path segment that contains more than one section, such as a literal section or a parameter, " +
+                "cannot contain a catch-all parameter." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -540,7 +584,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("foo/{{p1}"),
-                "There is an incomplete parameter in the route template. Check that each '{' character has a matching '}' character." + Environment.NewLine +
+                "There is an incomplete parameter in the route template. Check that each '{' character has a " +
+                "matching '}' character." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -549,7 +594,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("foo/{p1}}"),
-                "There is an incomplete parameter in the route template. Check that each '{' character has a matching '}' character." + Environment.NewLine +
+                "There is an incomplete parameter in the route template. Check that each '{' character has a " +
+                "matching '}' character." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -558,7 +604,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("{aaa}/{AAA}"),
-                "The route parameter name 'AAA' appears more than one time in the route template." + Environment.NewLine +
+                "The route parameter name 'AAA' appears more than one time in the route template." + 
+                Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -567,7 +614,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("{aaa}/{*AAA}"),
-                "The route parameter name 'AAA' appears more than one time in the route template." + Environment.NewLine +
+                "The route parameter name 'AAA' appears more than one time in the route template." + 
+                Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -576,7 +624,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("{a}/{aa}a}/{z}"),
-                "There is an incomplete parameter in the route template. Check that each '{' character has a matching '}' character." + Environment.NewLine +
+                "There is an incomplete parameter in the route template. Check that each '{' character has a " + 
+                "matching '}' character." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -621,7 +670,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("{a}//{z}"),
-                "The route template separator character '/' cannot appear consecutively. It must be separated by either a parameter or a literal value." + Environment.NewLine +
+                "The route template separator character '/' cannot appear consecutively. It must be separated by " +
+                "either a parameter or a literal value." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -630,7 +680,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("foo/{p1}/{*p2}/{p3}"),
-                "A catch-all parameter can only appear as the last segment of the route template." + Environment.NewLine +
+                "A catch-all parameter can only appear as the last segment of the route template." + 
+                Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -639,7 +690,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("foo/aa{p1}{p2}"),
-                "A path segment cannot contain two consecutive parameters. They must be separated by a '/' or by a literal string." + Environment.NewLine +
+                "A path segment cannot contain two consecutive parameters. They must be separated by a '/' or by " +
+                "a literal string." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -666,7 +718,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("foor?bar"),
-                "The literal section 'foor?bar' is invalid. Literal sections cannot contain the '?' character." + Environment.NewLine +
+                "The literal section 'foor?bar' is invalid. Literal sections cannot contain the '?' character." + 
+                Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 
@@ -687,7 +740,9 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("{foorb?}-bar-{z}"),
-                "A path segment that contains more than one section, such as a literal section or a parameter, cannot contain an optional parameter." + Environment.NewLine +
+                "In a path segment that contains more than one section, such as a literal section or a parameter, " +
+                "there can only be one optional parameter. The optional parameter must be the last parameter in " + 
+                "the segment and must be preceded by one single period (.)." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateRouteTest.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateRouteTest.cs
@@ -822,6 +822,24 @@ namespace Microsoft.AspNet.Routing.Template
         }
 
         [Fact]
+        public async Task Match_Success_OptionalParameter_DefaultValue()
+        {
+            // Arrange
+            var route = CreateRoute("{controller}/{action}.{format?}", new { action = "Index", format = "xml" });
+            var context = CreateRouteContext("/Home/Create");
+
+            // Act
+            await route.RouteAsync(context);
+
+            // Assert
+            Assert.True(context.IsHandled);
+            Assert.Equal(3, context.RouteData.Values.Count);
+            Assert.Equal("Home", context.RouteData.Values["controller"]);
+            Assert.Equal("Create", context.RouteData.Values["action"]);
+            Assert.Equal("xml", context.RouteData.Values["format"]);
+        }
+
+        [Fact]
         public async Task Match_Success_OptionalParameter_EndsWithDot()
         {
             // Arrange
@@ -1388,6 +1406,26 @@ namespace Microsoft.AspNet.Routing.Template
 
             // Assert
             Assert.Equal("Home/Index/products.xml", path);
+        }
+
+        [Fact]
+        public void GetVirtualPath_OptionalParameter_ParameterNotPresentInValues_PresentInDefaults()
+        {
+            // Arrange            
+            var route = CreateRoute(
+                template: "{controller}/{action}/{name}.{format?}",
+                defaults: new { format = "json" },
+                accept: true,
+                constraints: null);
+
+            var context = CreateVirtualPathContext(
+                values: new { action = "Index", controller = "Home", name = "products"});
+
+            // Act
+            var path = route.GetVirtualPath(context);
+
+            // Assert
+            Assert.Equal("Home/Index/products", path);
         }
 
         [Fact]

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateRouteTest.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateRouteTest.cs
@@ -786,6 +786,55 @@ namespace Microsoft.AspNet.Routing.Template
             Assert.Null(context.RouteData.Values["1controller"]);
         }
 
+        [Fact]
+        public async Task Match_Success_OptionalParameter_ValueProvided()
+        {
+            // Arrange
+            var route = CreateRoute("{controller}/{action}.{format?}", new { action = "Index" });
+            var context = CreateRouteContext("/Home/Create.xml");
+
+            // Act
+            await route.RouteAsync(context);
+
+            // Assert
+            Assert.True(context.IsHandled);
+            Assert.Equal(3, context.RouteData.Values.Count);
+            Assert.Equal("Home", context.RouteData.Values["controller"]);
+            Assert.Equal("Create", context.RouteData.Values["action"]);
+            Assert.Equal("xml", context.RouteData.Values["format"]);
+        }
+
+        [Fact]
+        public async Task Match_Success_OptionalParameter_ValueNotProvided()
+        {
+            // Arrange
+            var route = CreateRoute("{controller}/{action}.{format?}", new { action = "Index" });
+            var context = CreateRouteContext("/Home/Create");
+
+            // Act
+            await route.RouteAsync(context);
+
+            // Assert
+            Assert.True(context.IsHandled);
+            Assert.Equal(2, context.RouteData.Values.Count);
+            Assert.Equal("Home", context.RouteData.Values["controller"]);
+            Assert.Equal("Create", context.RouteData.Values["action"]);
+        }
+
+        [Fact]
+        public async Task Match_Success_OptionalParameter_EndsWithDot()
+        {
+            // Arrange
+            var route = CreateRoute("{controller}/{action}.{format?}", new { action = "Index" });
+            var context = CreateRouteContext("/Home/Create.");
+
+            // Act
+            await route.RouteAsync(context);
+
+            // Assert
+            Assert.False(context.IsHandled);
+        }
+
         private static RouteContext CreateRouteContext(string requestPath, ILoggerFactory factory = null)
         {
             if (factory == null)
@@ -995,7 +1044,8 @@ namespace Microsoft.AspNet.Routing.Template
 
             var route = CreateRoute(target.Object, "{controller}/{action}");
             var context = CreateVirtualPathContext(
-                new { action = "Store" }, new { Controller = "Home", action = "Blog" });
+                new { action = "Store" }, 
+                new { Controller = "Home", action = "Blog" });
 
             var expectedValues = new RouteValueDictionary(new { controller = "Home", action = "Store" });
 
@@ -1398,6 +1448,26 @@ namespace Microsoft.AspNet.Routing.Template
 
             // Assert
             Assert.Equal("Home/Index/", path);
+        }
+
+        [Fact]
+        public void GetVirtualPath_OptionalParameter_InSimpleSegment()
+        {
+            // Arrange            
+            var route = CreateRoute(
+                template: "{controller}/{action}/{name?}",
+                defaults: null,
+                accept: true,
+                constraints: null);
+
+            var context = CreateVirtualPathContext(
+                values: new { action = "Index", controller = "Home"});
+
+            // Act
+            var path = route.GetVirtualPath(context);
+
+            // Assert
+            Assert.Equal("Home/Index", path);
         }
 
         private static VirtualPathContext CreateVirtualPathContext(object values)


### PR DESCRIPTION
1. Template parser now allows a parameter to be an optional parameter in a complex segment if
   it is the last and only optional parameter and it is followed by a period.
2. Template matcher modified to take into consideration the optional parameter in the complex
   segment. Also the period shouldn't be present if the optional parameter is not present