### PR TITLE
Update QueryBuilder dependency

### DIFF
--- a/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.AspNet.WebUtilities;
+using Microsoft.AspNet.Http.Extensions;
 
 namespace Microsoft.AspNet.Routing.Template
 {

--- a/src/Microsoft.AspNet.Routing/project.json
+++ b/src/Microsoft.AspNet.Routing/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "Microsoft.AspNet.RequestContainer": "1.0.0-*",
-    "Microsoft.AspNet.WebUtilities": "1.0.0-*",
+    "Microsoft.AspNet.Http.Extensions": "1.0.0-*",
     "Microsoft.Framework.Logging": "1.0.0-*"
   },
   "frameworks": {


### PR DESCRIPTION
QueryBuilder has been moved from WebUtilities to Http.Extensions in order to clean up package dependencies.

RE:
aspnet/HttpAbstractions#164 - New header types
#163 - Remove WebUtility's dependency on Http

@rynowak @muratg 