### PR TITLE
AddRouting patch

### DIFF
--- a/src/Microsoft.AspNet.Routing/RoutingServices.cs
+++ b/src/Microsoft.AspNet.Routing/RoutingServices.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
+using System;
+using System.Threading.Tasks;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
 
@@ -8,10 +9,18 @@ namespace Microsoft.AspNet.Routing
 {
     public static class RoutingServices
     {
-        public static IServiceCollection AddRouting(this IServiceCollection services, IConfiguration config = null)
+        public static IServiceCollection AddRouting(this IServiceCollection services, IConfiguration config = null, Action<RouteOptions> configureOptions = null)
         {
             var describe = new ServiceDescriber(config);
+
+            services.AddOptions(config);
             services.TryAdd(describe.Transient<IInlineConstraintResolver, DefaultInlineConstraintResolver>());
+
+            if (configureOptions != null)
+            {
+                services.Configure(configureOptions);
+            }
+
             return services;
         }
     }


### PR DESCRIPTION
A patch that can avoid the following exception when using the MapRoute extension and also adds an extra configuration option parameter.

The exception that occurs (also when running the sample):
An exception of type 'System.InvalidOperationException' occurred in Microsoft.Framework.DependencyInjection.dll but was not handled in user code

Additional information: Unable to resolve service for type 'Microsoft.Framework.OptionsModel.IOptions`1[Microsoft.AspNet.Routing.RouteOptions]' while attempting to activate 'Microsoft.AspNet.Routing.DefaultInlineConstraintResolver'.