### PR TITLE
Quick cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ _ReSharper.*/
 packages/
 artifacts/
 PublishProfiles/
+.vs/
+debugSettings.json
 *.user
 *.suo
 *.cache

--- a/samples/RoutingSample.Web/RoutingSample.Web.kproj
+++ b/samples/RoutingSample.Web/RoutingSample.Web.kproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
+    <DevelopmentServerPort>25397</DevelopmentServerPort>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/Microsoft.AspNet.Routing/DefaultInlineConstraintResolver.cs
+++ b/src/Microsoft.AspNet.Routing/DefaultInlineConstraintResolver.cs
@@ -18,12 +18,15 @@ namespace Microsoft.AspNet.Routing
     public class DefaultInlineConstraintResolver : IInlineConstraintResolver
     {
         private readonly IDictionary<string, Type> _inlineConstraintMap;
-        private readonly IServiceProvider _serviceProvider;
 
-        public DefaultInlineConstraintResolver(IServiceProvider serviceProvider,
-                                               IOptions<RouteOptions> routeOptions)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultInlineConstraintResolver"/> class.
+        /// </summary>
+        /// <param name="routeOptions">
+        /// Accessor for <see cref="RouteOptions"/> containing the constraints of interest.
+        /// </param>
+        public DefaultInlineConstraintResolver(IOptions<RouteOptions> routeOptions)
         {
-            _serviceProvider = serviceProvider;
             _inlineConstraintMap = routeOptions.Options.ConstraintMap;
         }
 

--- a/test/Microsoft.AspNet.Routing.Tests/DefaultInlineConstraintResolverTest.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/DefaultInlineConstraintResolverTest.cs
@@ -302,10 +302,7 @@ namespace Microsoft.AspNet.Routing.Tests
         {
             var optionsAccessor = new Mock<IOptions<RouteOptions>>();
             optionsAccessor.SetupGet(o => o.Options).Returns(routeOptions);
-            var serviceProvider = new Mock<IServiceProvider>();
-            serviceProvider.Setup(o => o.GetService(It.Is<Type>(type => type == typeof(ITypeActivator))))
-                           .Returns(new TypeActivator());
-            return new DefaultInlineConstraintResolver(serviceProvider.Object, optionsAccessor.Object);
+            return new DefaultInlineConstraintResolver(optionsAccessor.Object);
         }
 
         private class MultiConstructorRouteConstraint : IRouteConstraint

--- a/test/Microsoft.AspNet.Routing.Tests/InlineRouteParameterParserTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/InlineRouteParameterParserTests.cs
@@ -300,7 +300,7 @@ namespace Microsoft.AspNet.Routing.Tests
                                 .Add("test", typeof(TestRouteConstraint)));
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
-            return new DefaultInlineConstraintResolver(serviceProvider, accessor);
+            return new DefaultInlineConstraintResolver(accessor);
         }
 
         private class TestRouteConstraint : IRouteConstraint

--- a/test/Microsoft.AspNet.Routing.Tests/RouteConstraintBuilderTest.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/RouteConstraintBuilderTest.cs
@@ -179,14 +179,12 @@ namespace Microsoft.AspNet.Routing
 
         private static RouteConstraintBuilder CreateBuilder(string template)
         {
-            var services = new Mock<IServiceProvider>(MockBehavior.Strict);
-
             var options = new Mock<IOptions<RouteOptions>>(MockBehavior.Strict);
             options
                 .SetupGet(o => o.Options)
                 .Returns(new RouteOptions());
 
-            var inlineConstraintResolver = new DefaultInlineConstraintResolver(services.Object, options.Object);
+            var inlineConstraintResolver = new DefaultInlineConstraintResolver(options.Object);
             return new RouteConstraintBuilder(inlineConstraintResolver, template);
         }
     }

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
@@ -1182,7 +1182,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
             var services = new ServiceCollection().AddOptions();
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
-            return new DefaultInlineConstraintResolver(serviceProvider, accessor);
+            return new DefaultInlineConstraintResolver(accessor);
         }
 
         private class PathAndQuery

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateMatcherTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateMatcherTests.cs
@@ -929,7 +929,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
             var services = new ServiceCollection().AddOptions();
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
-            return new DefaultInlineConstraintResolver(serviceProvider, accessor);
+            return new DefaultInlineConstraintResolver(accessor);
         }
     }
 }

--- a/test/Microsoft.AspNet.Routing.Tests/TemplateParserDefaultValuesTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/TemplateParserDefaultValuesTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNet.Routing.Tests
             var services = new ServiceCollection().AddOptions();
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
-            return new DefaultInlineConstraintResolver(serviceProvider, accessor);
+            return new DefaultInlineConstraintResolver(accessor);
         }
     }
 }


### PR DESCRIPTION
- `DefaultInlineConstraintResolver` has no need of a `IServiceProvider`

nits:
- add doc comments for changed `DefaultInlineConstraintResolver` ctor
- let VS add a dev server port to sample's .kproj
- add debugSettings.json and .vs/ to .gitignore