### PR TITLE
Changed package versions to fixed ones

### DIFF
--- a/samples/RoutingSample.Web/project.json
+++ b/samples/RoutingSample.Web/project.json
@@ -1,9 +1,9 @@
 {
     "dependencies": {
-        "Kestrel": "1.0.0-*",
-        "Microsoft.AspNet.Server.IIS": "1.0.0-*",
-        "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
-        "Microsoft.AspNet.Routing": "1.0.0-*"
+        "Kestrel": "1.0.0-beta2",
+        "Microsoft.AspNet.Server.IIS": "1.0.0-beta2",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta2",
+        "Microsoft.AspNet.Routing": "1.0.0-beta2"
     },
     "commands": {
         "web": "Microsoft.AspNet.Hosting server=Microsoft.AspNet.Server.WebListener server.urls=http://localhost:5001",

--- a/src/Microsoft.AspNet.Routing/project.json
+++ b/src/Microsoft.AspNet.Routing/project.json
@@ -1,20 +1,20 @@
 {
   "description": "ASP.NET 5 middleware and abstractions for routing requests to application logic and for generating links.",
-  "version": "1.0.0-*",
+  "version": "1.0.0-beta2",
   "compilationOptions": {
     "warningsAsErrors": true
   },
   "dependencies": {
-    "Microsoft.AspNet.RequestContainer": "1.0.0-*",
-    "Microsoft.AspNet.WebUtilities": "1.0.0-*",
-    "Microsoft.Framework.Logging": "1.0.0-*"
+    "Microsoft.AspNet.RequestContainer": "1.0.0-beta2",
+    "Microsoft.AspNet.WebUtilities": "1.0.0-beta2",
+    "Microsoft.Framework.Logging": "1.0.0-beta2"
   },
   "frameworks": {
     "aspnet50": {},
     "aspnetcore50": {
       "dependencies": {
-        "System.Reflection.Extensions": "4.0.0-beta-*",
-        "System.Text.RegularExpressions": "4.0.10-beta-*"
+        "System.Reflection.Extensions": "4.0.0-beta-22416",
+        "System.Text.RegularExpressions": "4.0.10-beta-22416"
       }
     }
   }

--- a/test/Microsoft.AspNet.Routing.Tests/project.json
+++ b/test/Microsoft.AspNet.Routing.Tests/project.json
@@ -3,10 +3,10 @@
         "warningsAsErrors": "true"
     },
     "dependencies": {
-        "Microsoft.AspNet.PipelineCore": "1.0.0-*",
-        "Microsoft.AspNet.Routing": "1.0.0-*",
-        "Microsoft.AspNet.Testing": "1.0.0-*",
-        "Xunit.KRunner": "1.0.0-*"
+        "Microsoft.AspNet.PipelineCore": "1.0.0-beta2",
+        "Microsoft.AspNet.Routing": "1.0.0-beta2",
+        "Microsoft.AspNet.Testing": "1.0.0-beta2",
+        "xunit.runner.kre": "1.0.0-*"
     },
     "frameworks": {
         "aspnetcore50": {},
@@ -17,6 +17,6 @@
         }
     },
     "commands": {
-        "test": "Xunit.KRunner"
+        "test": "xunit.runner.kre"
     }
 }


### PR DESCRIPTION
@yishaigalatzer @rynowak 

Just FYI...the Xunit packages are not available on public Nuget feed and we are figuring out if we need to create a separate feed for external packages, but other than that please take a look at the changes to other packages.