### PR TITLE
Fixing 148

### DIFF
--- a/src/Microsoft.AspNet.Routing/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Routing/Properties/Resources.Designer.cs
@@ -394,6 +394,38 @@ namespace Microsoft.AspNet.Routing
             return GetString("TemplateRoute_UnescapedBrace");
         }
 
+        /// <summary>
+        /// The complex segment '{0}' has an optional parameter preceded by an invalid segment '{1}'. Only valid literal to precede an optional parameter is a period (.).
+        /// </summary>
+        internal static string TemplateRoute_OptionalParameterCanbBePrecededByPeriod
+        {
+            get { return GetString("TemplateRoute_OptionalParameterCanbBePrecededByPeriod"); }
+        }
+
+        /// <summary>
+        /// The complex segment '{0}' has an optional parameter preceded by an invalid segment '{1}'. Only valid literal to precede an optional parameter is a period (.).
+        /// </summary>
+        internal static string FormatTemplateRoute_OptionalParameterCanbBePrecededByPeriod(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TemplateRoute_OptionalParameterCanbBePrecededByPeriod"), p0, p1);
+        }
+
+        /// <summary>
+        /// In the complex segment '{0}', optional parameter '{1}' should be the last parameter. No literal or parameter is not allowed after optional parameter.
+        /// </summary>
+        internal static string TemplateRoute_OptionalParameterHasTobeTheLast
+        {
+            get { return GetString("TemplateRoute_OptionalParameterHasTobeTheLast"); }
+        }
+
+        /// <summary>
+        /// In the complex segment '{0}', optional parameter '{1}' should be the last parameter. No literal or parameter is not allowed after optional parameter.
+        /// </summary>
+        internal static string FormatTemplateRoute_OptionalParameterHasTobeTheLast(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TemplateRoute_OptionalParameterHasTobeTheLast"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.AspNet.Routing/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Routing/Properties/Resources.Designer.cs
@@ -203,22 +203,6 @@ namespace Microsoft.AspNet.Routing
         }
 
         /// <summary>
-        /// In a path segment that contains more than one section, such as a literal section or a parameter, there can only be one optional parameter. The optional parameter must be the last parameter in the segment and must be preceded by one single period (.).
-        /// </summary>
-        internal static string TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator
-        {
-            get { return GetString("TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator"); }
-        }
-
-        /// <summary>
-        /// In a path segment that contains more than one section, such as a literal section or a parameter, there can only be one optional parameter. The optional parameter must be the last parameter in the segment and must be preceded by one single period (.).
-        /// </summary>
-        internal static string FormatTemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator()
-        {
-            return GetString("TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator");
-        }
-
-        /// <summary>
         /// A catch-all parameter cannot be marked optional.
         /// </summary>
         internal static string TemplateRoute_CatchAllCannotBeOptional
@@ -395,7 +379,7 @@ namespace Microsoft.AspNet.Routing
         }
 
         /// <summary>
-        /// The complex segment '{0}' has an optional parameter preceded by an invalid segment '{1}'. Only valid literal to precede an optional parameter is a period (.).
+        /// In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'. Only valid literal to precede an optional parameter is a period (.).
         /// </summary>
         internal static string TemplateRoute_OptionalParameterCanbBePrecededByPeriod
         {
@@ -403,15 +387,15 @@ namespace Microsoft.AspNet.Routing
         }
 
         /// <summary>
-        /// The complex segment '{0}' has an optional parameter preceded by an invalid segment '{1}'. Only valid literal to precede an optional parameter is a period (.).
+        /// In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'. Only valid literal to precede an optional parameter is a period (.).
         /// </summary>
-        internal static string FormatTemplateRoute_OptionalParameterCanbBePrecededByPeriod(object p0, object p1)
+        internal static string FormatTemplateRoute_OptionalParameterCanbBePrecededByPeriod(object p0, object p1, object p2)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("TemplateRoute_OptionalParameterCanbBePrecededByPeriod"), p0, p1);
+            return string.Format(CultureInfo.CurrentCulture, GetString("TemplateRoute_OptionalParameterCanbBePrecededByPeriod"), p0, p1, p2);
         }
 
         /// <summary>
-        /// In the complex segment '{0}', optional parameter '{1}' should be the last parameter. No literal or parameter is not allowed after optional parameter.
+        /// In the segment '{0}', optional parameter '{1}' should be the last parameter. An optional parameter must be at the end of the segment, it was followed by '{2}'
         /// </summary>
         internal static string TemplateRoute_OptionalParameterHasTobeTheLast
         {
@@ -419,11 +403,11 @@ namespace Microsoft.AspNet.Routing
         }
 
         /// <summary>
-        /// In the complex segment '{0}', optional parameter '{1}' should be the last parameter. No literal or parameter is not allowed after optional parameter.
+        /// In the segment '{0}', optional parameter '{1}' should be the last parameter. An optional parameter must be at the end of the segment, it was followed by '{2}'
         /// </summary>
-        internal static string FormatTemplateRoute_OptionalParameterHasTobeTheLast(object p0, object p1)
+        internal static string FormatTemplateRoute_OptionalParameterHasTobeTheLast(object p0, object p1, object p2)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("TemplateRoute_OptionalParameterHasTobeTheLast"), p0, p1);
+            return string.Format(CultureInfo.CurrentCulture, GetString("TemplateRoute_OptionalParameterHasTobeTheLast"), p0, p1, p2);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.AspNet.Routing/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.Routing/Properties/Resources.Designer.cs
@@ -379,7 +379,7 @@ namespace Microsoft.AspNet.Routing
         }
 
         /// <summary>
-        /// In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'. Only valid literal to precede an optional parameter is a period (.).
+        /// In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'.  Only a period (.) can precede an optional parameter.
         /// </summary>
         internal static string TemplateRoute_OptionalParameterCanbBePrecededByPeriod
         {
@@ -387,7 +387,7 @@ namespace Microsoft.AspNet.Routing
         }
 
         /// <summary>
-        /// In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'. Only valid literal to precede an optional parameter is a period (.).
+        /// In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'.  Only a period (.) can precede an optional parameter.
         /// </summary>
         internal static string FormatTemplateRoute_OptionalParameterCanbBePrecededByPeriod(object p0, object p1, object p2)
         {
@@ -395,7 +395,7 @@ namespace Microsoft.AspNet.Routing
         }
 
         /// <summary>
-        /// In the segment '{0}', optional parameter '{1}' should be the last parameter. An optional parameter must be at the end of the segment, it was followed by '{2}'
+        /// An optional parameter must be at the end of the segment. In the segment '{0}', optional parameter '{1}' is followed by '{2}'.
         /// </summary>
         internal static string TemplateRoute_OptionalParameterHasTobeTheLast
         {
@@ -403,7 +403,7 @@ namespace Microsoft.AspNet.Routing
         }
 
         /// <summary>
-        /// In the segment '{0}', optional parameter '{1}' should be the last parameter. An optional parameter must be at the end of the segment, it was followed by '{2}'
+        /// An optional parameter must be at the end of the segment. In the segment '{0}', optional parameter '{1}' is followed by '{2}'.
         /// </summary>
         internal static string FormatTemplateRoute_OptionalParameterHasTobeTheLast(object p0, object p1, object p2)
         {

--- a/src/Microsoft.AspNet.Routing/Resources.resx
+++ b/src/Microsoft.AspNet.Routing/Resources.resx
@@ -187,9 +187,9 @@
     <value>In a route parameter, '{' and '}' must be escaped with '{{' and '}}'</value>
   </data>
   <data name="TemplateRoute_OptionalParameterCanbBePrecededByPeriod" xml:space="preserve">
-    <value>In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'. Only valid literal to precede an optional parameter is a period (.).</value>
+    <value>In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'.  Only a period (.) can precede an optional parameter.</value>
   </data>
   <data name="TemplateRoute_OptionalParameterHasTobeTheLast" xml:space="preserve">
-    <value>In the segment '{0}', optional parameter '{1}' should be the last parameter. An optional parameter must be at the end of the segment, it was followed by '{2}'</value>
+    <value>An optional parameter must be at the end of the segment. In the segment '{0}', optional parameter '{1}' is followed by '{2}'.</value>
   </data>
 </root>

--- a/src/Microsoft.AspNet.Routing/Resources.resx
+++ b/src/Microsoft.AspNet.Routing/Resources.resx
@@ -153,9 +153,6 @@
   <data name="TemplateRoute_CannotHaveConsecutiveSeparators" xml:space="preserve">
     <value>The route template separator character '/' cannot appear consecutively. It must be separated by either a parameter or a literal value.</value>
   </data>
-  <data name="TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator" xml:space="preserve">
-    <value>In a path segment that contains more than one section, such as a literal section or a parameter, there can only be one optional parameter. The optional parameter must be the last parameter in the segment and must be preceded by one single period (.).</value>
-  </data>
   <data name="TemplateRoute_CatchAllCannotBeOptional" xml:space="preserve">
     <value>A catch-all parameter cannot be marked optional.</value>
   </data>
@@ -190,9 +187,9 @@
     <value>In a route parameter, '{' and '}' must be escaped with '{{' and '}}'</value>
   </data>
   <data name="TemplateRoute_OptionalParameterCanbBePrecededByPeriod" xml:space="preserve">
-    <value>In the complex segment '{0}',  the optional parameter '{1}' is preceded by an invalid segment '{2}'. Only valid literal to precede an optional parameter is a period (.).</value>
+    <value>In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'. Only valid literal to precede an optional parameter is a period (.).</value>
   </data>
   <data name="TemplateRoute_OptionalParameterHasTobeTheLast" xml:space="preserve">
-    <value>In the complex segment '{0}', optional parameter '{1}' should be the last parameter. No literal or parameter is not allowed after optional parameter.</value>
+    <value>In the segment '{0}', optional parameter '{1}' should be the last parameter. An optional parameter must be at the end of the segment, it was followed by '{2}'</value>
   </data>
 </root>

--- a/src/Microsoft.AspNet.Routing/Resources.resx
+++ b/src/Microsoft.AspNet.Routing/Resources.resx
@@ -189,4 +189,10 @@
   <data name="TemplateRoute_UnescapedBrace" xml:space="preserve">
     <value>In a route parameter, '{' and '}' must be escaped with '{{' and '}}'</value>
   </data>
+  <data name="TemplateRoute_OptionalParameterCanbBePrecededByPeriod" xml:space="preserve">
+    <value>In the complex segment '{0}',  the optional parameter '{1}' is preceded by an invalid segment '{2}'. Only valid literal to precede an optional parameter is a period (.).</value>
+  </data>
+  <data name="TemplateRoute_OptionalParameterHasTobeTheLast" xml:space="preserve">
+    <value>In the complex segment '{0}', optional parameter '{1}' should be the last parameter. No literal or parameter is not allowed after optional parameter.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
@@ -366,17 +366,20 @@ namespace Microsoft.AspNet.Routing.Template
                             return false;
                         }
                     }
-                    // This optional parameter is not the last one in the segment
                     else
                     {
+                        // This optional parameter is not the last one in the segment
                         // Example:
-                        //In the complex segment "{RouteValue?})" optional parameter "RouteValue" should be the 
-                        //last parameter.No literal or parameter is not allowed after optional parameter.
+                        // An optional parameter must be at the end of the segment.In the segment '{RouteValue?})', 
+                        // optional parameter 'RouteValue' is followed by ')'
+                        var nextPart = segment.Parts[i + 1];
+                        var invalidPartText = nextPart.IsParameter ? nextPart.Name : nextPart.Text;
+
                         context.Error = string.Format(
                             Resources.TemplateRoute_OptionalParameterHasTobeTheLast,
                             segment.DebuggerToString(),
                             segment.Parts[i].Name,
-                            segment.Parts[i+1].Name
+                            invalidPartText
                             );
 
                         return false;

--- a/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
@@ -375,7 +375,9 @@ namespace Microsoft.AspNet.Routing.Template
                         context.Error = string.Format(
                             Resources.TemplateRoute_OptionalParameterHasTobeTheLast,
                             segment.DebuggerToString(),
-                            segment.Parts[i].Name);
+                            segment.Parts[i].Name,
+                            segment.Parts[i+1].Name
+                            );
 
                         return false;
                     }

--- a/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
@@ -340,26 +340,43 @@ namespace Microsoft.AspNet.Routing.Template
 
                 if (part.IsParameter && part.IsOptional && segment.Parts.Count > 1)
                 {
-                    // This is the last part
+                    // This optional parameter is the last part in the segment
                     if (i == segment.Parts.Count - 1)
                     {
                         Debug.Assert(segment.Parts[i - 1].IsLiteral);
 
+                        // the optional parameter is preceded by a period
                         if (segment.Parts[i - 1].Text == PeriodString)
                         {
                             segment.Parts[i - 1].IsOptionalSeperator = true;
                         }
                         else
                         {
-                            context.Error = 
-                                Resources.TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator;
+                            // The optional parameter is preceded by a literal other than period
+                            // Example of error message:
+                            // "In the complex segment {RouteValue}-{param?}, the optional parameter 'param'is preceded
+                            // by an invalid segment "-". Only valid literal to precede an optional parameter is a 
+                            // period (.).
+                            context.Error = string.Format(
+                                Resources.TemplateRoute_OptionalParameterCanbBePrecededByPeriod,
+                                segment.DebuggerToString(),
+                                part.Name,
+                                segment.Parts[i - 1].Text);
+
                             return false;
                         }
                     }
+                    // This optional parameter is not the last one in the segment
                     else
                     {
-                        context.Error = 
-                            Resources.TemplateRoute_CanHaveOnlyLastParameterOptional_IfFollowingOptionalSeperator;
+                        // Example:
+                        //In the complex segment "{RouteValue?})" optional parameter "RouteValue" should be the 
+                        //last parameter.No literal or parameter is not allowed after optional parameter.
+                        context.Error = string.Format(
+                            Resources.TemplateRoute_OptionalParameterHasTobeTheLast,
+                            segment.DebuggerToString(),
+                            segment.Parts[i].Name);
+
                         return false;
                     }
                 }

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateParserTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateParserTests.cs
@@ -528,17 +528,22 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         }
 
         [Theory]
-        [InlineData("{p1}.{p2?}.{p3}", "p2")]
-        [InlineData("{p1?}.{p2}", "p1")]
-        [InlineData("{p1?}{p2?}", "p1")]
-        public void Parse_ComplexSegment_OptionalParameter_NotTheLastPart(string template, string parameter)
+        [InlineData("{p1}.{p2?}.{p3}", "p2", ".")]
+        [InlineData("{p1?}{p2}", "p1", "p2")]
+        [InlineData("{p1?}{p2?}", "p1", "p2")]
+        [InlineData("{p1}.{p2?})", "p2", ")")]
+        [InlineData("{foorb?}-bar-{z}", "foorb", "-bar-")]
+        public void Parse_ComplexSegment_OptionalParameter_NotTheLastPart(
+            string template, 
+            string parameter, 
+            string invalid)
         {
             // Act and Assert
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse(template),
-                "In the complex segment '" + template + "', optional parameter '" + parameter + "' should be the last " +
-                "parameter. No literal or parameter is not allowed after optional parameter." + Environment.NewLine +
-                "Parameter name: routeTemplate");
+                "An optional parameter must be at the end of the segment. In the segment '" + template +
+                "', optional parameter '" + parameter + "' is followed by '" + invalid + "'."
+                 + Environment.NewLine + "Parameter name: routeTemplate");
         }
 
         [InlineData("{p1}-{p2?}", "-")]
@@ -800,16 +805,6 @@ namespace Microsoft.AspNet.Routing.Template.Tests
                 " contain these characters: '{', '}', '/'. The '?' character marks a parameter as optional, and" +
                 " can occur only at the end of the parameter. The '*' character marks a parameter as catch-all," +
                 " and can occur only at the start of the parameter." + Environment.NewLine +
-                "Parameter name: routeTemplate");
-        }
-
-        [Fact]
-        public void InvalidTemplate_MultiSegmentParameterCannotContainOptionalParameter()
-        {
-            ExceptionAssert.Throws<ArgumentException>(
-                () => TemplateParser.Parse("{foorb?}-bar-{z}"),
-                @"In the complex segment '{foorb?}-bar-{z}', optional parameter 'foorb' should be the last " +
-                "parameter. No literal or parameter is not allowed after optional parameter." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateParserTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateParserTests.cs
@@ -528,23 +528,32 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         }
 
         [Theory]
-        [InlineData("{p1?}.{p2?}")]
-        [InlineData("{p1}.{p2?}.{p3}")]
-        [InlineData("{p1?}.{p2}/{p3}")]
-        [InlineData("{p3}.{p1?}.{p2?}")]
-        [InlineData("{p1}-{p2?}")]
-        [InlineData("{p1}..{p2?}")]
-        [InlineData("..{p2?}")]
-        [InlineData("{p1}.abc.{p2?}")]
-        public void Parse_ComplexSegment_OptionalParametersSeperatedByPeriod_Invalid(string template)
+        [InlineData("{p1}.{p2?}.{p3}", "p2")]
+        [InlineData("{p1?}.{p2}", "p1")]
+        [InlineData("{p1?}{p2?}", "p1")]
+        public void Parse_ComplexSegment_OptionalParameter_NotTheLastPart(string template, string parameter)
         {
             // Act and Assert
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse(template),
-                "In a path segment that contains more than one section, such as a literal section or a parameter, " +
-                "there can only be one optional parameter. The optional parameter must be the last parameter in the " +
-                "segment and must be preceded by one single period (.)." + Environment.NewLine +
+                "In the complex segment '" + template + "', optional parameter '" + parameter + "' should be the last " +
+                "parameter. No literal or parameter is not allowed after optional parameter." + Environment.NewLine +
                 "Parameter name: routeTemplate");
+        }
+
+        [InlineData("{p1}-{p2?}", "-")]
+        [InlineData("{p1}..{p2?}", "..")]
+        [InlineData("..{p2?}", "..")]
+        [InlineData("{p1}.abc.{p2?}", ".abc.")]
+        [InlineData("{p1}{p2?}", "p1")]
+        public void Parse_ComplexSegment_OptionalParametersSeperatedByPeriod_Invalid(string template, string parameter)
+        {
+            // Act and Assert
+            ExceptionAssert.Throws<ArgumentException>(
+                () => TemplateParser.Parse(template),
+                "In the complex segment '"+ template +"',  the optional parameter 'p2' is preceded by an invalid " + 
+                "segment '" + parameter +"'. Only valid literal to precede an optional parameter is a period (.)." + 
+                Environment.NewLine + "Parameter name: routeTemplate");
         }
 
         [Fact]
@@ -626,7 +635,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         [InlineData("{p}}}", "p}")]
         [InlineData("{p/}", "p/")]
         public void ParseRouteParameter_ThrowsIf_ParameterContainsSpecialCharacters(
-            string template, 
+            string template,
             string parameterName)
         {
             // Arrange
@@ -799,9 +808,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         {
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse("{foorb?}-bar-{z}"),
-                "In a path segment that contains more than one section, such as a literal section or a parameter, " +
-                "there can only be one optional parameter. The optional parameter must be the last parameter in " +
-                "the segment and must be preceded by one single period (.)." + Environment.NewLine +
+                @"In the complex segment '{foorb?}-bar-{z}', optional parameter 'foorb' should be the last " +
+                "parameter. No literal or parameter is not allowed after optional parameter." + Environment.NewLine +
                 "Parameter name: routeTemplate");
         }
 


### PR DESCRIPTION
Fixing the error message. The error message for malformed template was too complex listing all the errors that can happen in the message. I have separated the message in 2 different messages. 
1. When there is a parameter or a literal following the optional parameter.
2. when optional parameter is preceded by a literal other than period which is not allowed. 
 
 @rynowak @yishaigalatzer please have a look. 