### PR TITLE
Fix routing sample

### DIFF
--- a/src/Microsoft.AspNet.Routing/RoutingServices.cs
+++ b/src/Microsoft.AspNet.Routing/RoutingServices.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Framework.DependencyInjection
     {
         public static IServiceCollection AddRouting(this IServiceCollection services)
         {
+            services.AddOptions();
             services.TryAdd(ServiceDescriptor.Transient<IInlineConstraintResolver, DefaultInlineConstraintResolver>());
             return services;
         }


### PR DESCRIPTION
@rynowak @HaoK

Issue:
The routing sample currently throws an exception when run as its unable to resolve the `IOptions<Routing>` service required on `DefaultInlineConstraintResolver`.

Some Info:
I initially suspected that the change in this PR is going to effect MVC as the `AddMvc` extension also adds `AddOptions`.
https://github.com/aspnet/Mvc/blob/015edefa96c2eec7a474489a93a533e10ac74c7e/src/Microsoft.AspNet.Mvc/MvcServiceCollectionExtensions.cs#L90

But after making a local Routing repo change, I build and ran MVC repo against this change and all tests passed.

BTW, the `AddDataProtection` extension also internally does `AddOptions`.