### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.AspNet.Routing/Constraints/LengthRouteConstraint.cs
+++ b/src/Microsoft.AspNet.Routing/Constraints/LengthRouteConstraint.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.Routing.Constraints
             if (length < 0)
             {
                 var errorMessage = Resources.FormatArgumentMustBeGreaterThanOrEqualTo(0);
-                throw new ArgumentOutOfRangeException("length", length, errorMessage);
+                throw new ArgumentOutOfRangeException(nameof(length), errorMessage);
             }
 
             MinLength = MaxLength = length;
@@ -41,20 +41,20 @@ namespace Microsoft.AspNet.Routing.Constraints
             if (minLength < 0)
             {
                 var errorMessage = Resources.FormatArgumentMustBeGreaterThanOrEqualTo(0);
-                throw new ArgumentOutOfRangeException("minLength", minLength, errorMessage);
+                throw new ArgumentOutOfRangeException(nameof(minLength), errorMessage);
             }
 
             if (maxLength < 0)
             {
                 var errorMessage = Resources.FormatArgumentMustBeGreaterThanOrEqualTo(0);
-                throw new ArgumentOutOfRangeException("maxLength", maxLength, errorMessage);
+                throw new ArgumentOutOfRangeException(nameof(maxLength), errorMessage);
             }
 
             if (minLength > maxLength)
             {
                 var errorMessage =
                     Resources.FormatRangeConstraint_MinShouldBeLessThanOrEqualToMax("minLength", "maxLength");
-                throw new ArgumentOutOfRangeException("minLength", minLength, errorMessage);
+                throw new ArgumentOutOfRangeException(nameof(minLength), errorMessage);
             }
 
             MinLength = minLength;

--- a/src/Microsoft.AspNet.Routing/Constraints/MaxLengthRouteConstraint.cs
+++ b/src/Microsoft.AspNet.Routing/Constraints/MaxLengthRouteConstraint.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNet.Routing.Constraints
             if (maxLength < 0)
             {
                 var errorMessage = Resources.FormatArgumentMustBeGreaterThanOrEqualTo(0);
-                throw new ArgumentOutOfRangeException("maxLength", maxLength, errorMessage);
+                throw new ArgumentOutOfRangeException(nameof(maxLength), errorMessage);
             }
 
             MaxLength = maxLength;

--- a/src/Microsoft.AspNet.Routing/Constraints/MinLengthRouteConstraint.cs
+++ b/src/Microsoft.AspNet.Routing/Constraints/MinLengthRouteConstraint.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNet.Routing.Constraints
             if (minLength < 0)
             {
                 var errorMessage = Resources.FormatArgumentMustBeGreaterThanOrEqualTo(0);
-                throw new ArgumentOutOfRangeException("minLength", minLength, errorMessage);
+                throw new ArgumentOutOfRangeException(nameof(minLength), errorMessage);
             }
 
             MinLength = minLength;

--- a/src/Microsoft.AspNet.Routing/Constraints/RangeRouteConstraint.cs
+++ b/src/Microsoft.AspNet.Routing/Constraints/RangeRouteConstraint.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNet.Routing.Constraints
             if (min > max)
             {
                 var errorMessage = Resources.FormatRangeConstraint_MinShouldBeLessThanOrEqualToMax("min", "max");
-                throw new ArgumentOutOfRangeException("min", min, errorMessage);
+                throw new ArgumentOutOfRangeException(nameof(min), errorMessage);
             }
 
             Min = min;

--- a/src/Microsoft.AspNet.Routing/RouteContext.cs
+++ b/src/Microsoft.AspNet.Routing/RouteContext.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.Routing
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value");
+                    throw new ArgumentNullException(nameof(value));
                 }
 
                 _routeData = value;

--- a/src/Microsoft.AspNet.Routing/RouteOptions.cs
+++ b/src/Microsoft.AspNet.Routing/RouteOptions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNet.Routing
             {
                 if (value == null)
                 {
-                    throw new ArgumentNullException("value",
+                    throw new ArgumentNullException(nameof(value),
                                                     Resources.FormatPropertyOfTypeCannotBeNull(
                                                                 "ConstraintMap", typeof(RouteOptions)));
                 }

--- a/src/Microsoft.AspNet.Routing/Template/RouteTemplate.cs
+++ b/src/Microsoft.AspNet.Routing/Template/RouteTemplate.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNet.Routing.Template
         {
             if (segments == null)
             {
-                throw new ArgumentNullException("segments");
+                throw new ArgumentNullException(nameof(segments));
             }
 
             Segments = segments;

--- a/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Routing.Template
         {
             if (template == null)
             {
-                throw new ArgumentNullException("template");
+                throw new ArgumentNullException(nameof(template));
             }
 
             _template = template;
@@ -361,7 +361,7 @@ namespace Microsoft.AspNet.Routing.Template
             {
                 if (values == null)
                 {
-                    throw new ArgumentNullException("values");
+                    throw new ArgumentNullException(nameof(values));
                 }
 
                 _defaults = defaults;

--- a/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateParser.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.Routing.Template
 
             if (IsInvalidRouteTemplate(routeTemplate))
             {
-                throw new ArgumentException(Resources.TemplateRoute_InvalidRouteTemplate, "routeTemplate");
+                throw new ArgumentException(Resources.TemplateRoute_InvalidRouteTemplate, nameof(routeTemplate);
             }
 
             var context = new TemplateParserContext(routeTemplate);
@@ -41,13 +41,13 @@ namespace Microsoft.AspNet.Routing.Template
                     // If we get here is means that there's a consecutive '/' character.
                     // Templates don't start with a '/' and parsing a segment consumes the separator.
                     throw new ArgumentException(Resources.TemplateRoute_CannotHaveConsecutiveSeparators,
-                                                "routeTemplate");
+                                                nameof(routeTemplate));
                 }
                 else
                 {
                     if (!ParseSegment(context, segments))
                     {
-                        throw new ArgumentException(context.Error, "routeTemplate");
+                        throw new ArgumentException(context.Error, nameof(routeTemplate));
                     }
                 }
             }
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.Routing.Template
             }
             else
             {
-                throw new ArgumentException(context.Error, "routeTemplate");
+                throw new ArgumentException(context.Error, nameof(routeTemplate));
             }
         }
 


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason