### PR TITLE
Add access to Optional state of parameters to TemplateRoute

### DIFF
--- a/src/Microsoft.AspNet.Routing/Template/TemplateRoute.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateRoute.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Http;
 using Microsoft.Framework.DependencyInjection;
@@ -15,6 +16,7 @@ namespace Microsoft.AspNet.Routing.Template
         private readonly IReadOnlyDictionary<string, IRouteConstraint> _constraints;
         private readonly IReadOnlyDictionary<string, object> _dataTokens;
         private readonly IReadOnlyDictionary<string, object> _defaults;
+        private readonly IReadOnlyDictionary<string, bool> _optionals;
         private readonly IRouter _target;
         private readonly RouteTemplate _parsedTemplate;
         private readonly string _routeTemplate;
@@ -74,6 +76,7 @@ namespace Microsoft.AspNet.Routing.Template
 
             _constraints = GetConstraints(inlineConstraintResolver, RouteTemplate, _parsedTemplate, constraints);
             _defaults = GetDefaults(_parsedTemplate, defaults);
+            _optionals = GetOptionals(_parsedTemplate);
 
             _matcher = new TemplateMatcher(_parsedTemplate, Defaults);
             _binder = new TemplateBinder(_parsedTemplate, Defaults);
@@ -89,6 +92,11 @@ namespace Microsoft.AspNet.Routing.Template
         public IReadOnlyDictionary<string, object> DataTokens
         {
             get { return _dataTokens; }
+        }
+
+        public IReadOnlyDictionary<string, bool> Optionals
+        {
+            get { return _optionals; }
         }
 
         public string RouteTemplate
@@ -308,6 +316,12 @@ namespace Microsoft.AspNet.Routing.Template
             }
 
             return result;
+        }
+        
+        private static IReadOnlyDictionary<string, bool> GetOptionals(RouteTemplate parsedTemplate)
+        {
+            return parsedTemplate.Parameters
+                .ToDictionary(parameter => parameter.Name, parameter => parameter.IsOptional);
         }
 
         private static void MergeValues(

--- a/test/Microsoft.AspNet.Routing.Tests/TemplateParserOptionalValuesTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/TemplateParserOptionalValuesTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if DNX451
+
+using System;
+using System.Linq;
+using Microsoft.AspNet.Builder;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.OptionsModel;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.Routing.Tests
+{
+    public class TemplateParserOptionalValuesTests
+    {
+        private static IInlineConstraintResolver _inlineConstraintResolver = GetInlineConstraintResolver();
+
+        [Fact]
+        public void MandatoryParametersAreMarkedAsNotOptional()
+        {
+            // Arrange & Act
+            var routeBuilder = CreateRouteBuilder();
+
+            // Act
+            routeBuilder.MapRoute("mockName", "{controller}/{action}/{name}");
+
+            // Assert
+            var optionals = ((Template.TemplateRoute)routeBuilder.Routes[0]).Optionals;
+            Assert.False(optionals["name"]);
+        }
+
+        [Fact]
+        public void NonMandatoryParametersAreMarkedAsOptional()
+        {
+            // Arrange & Act
+            var routeBuilder = CreateRouteBuilder();
+
+            // Act
+            routeBuilder.MapRoute("mockName", "{controller}/{action}/{name?}");
+
+            // Assert
+            var optionals = ((Template.TemplateRoute)routeBuilder.Routes[0]).Optionals;
+            Assert.True(optionals["name"]);
+        }
+
+        [Fact]
+        public void CorrectNumberOfMandatoryParametershereDetectedWhenPresent()
+        {
+            // Arrange & Act
+            var routeBuilder = CreateRouteBuilder();
+
+            // Act
+            routeBuilder.MapRoute("mockName", "test/{controller}/{action}/{name?}");
+
+            // Assert
+            var optionals = ((Template.TemplateRoute)routeBuilder.Routes[0]).Optionals;
+            Assert.Equal(3, optionals.Keys.Count());
+        }
+
+        [Fact]
+        public void CorrectNumberOfMandatoryParametershereDetectedWhenNotPresent()
+        {
+            // Arrange & Act
+            var routeBuilder = CreateRouteBuilder();
+
+            // Act
+            routeBuilder.MapRoute("mockName", "test/hello");
+
+            // Assert
+            var optionals = ((Template.TemplateRoute)routeBuilder.Routes[0]).Optionals;
+            Assert.Equal(0, optionals.Keys.Count());
+        }
+
+        private static IRouteBuilder CreateRouteBuilder()
+        {
+            var routeBuilder = new RouteBuilder();
+
+            routeBuilder.DefaultHandler = new Mock<IRouter>().Object;
+
+            var serviceProviderMock = new Mock<IServiceProvider>();
+            serviceProviderMock.Setup(o => o.GetService(typeof(IInlineConstraintResolver)))
+                               .Returns(_inlineConstraintResolver);
+            routeBuilder.ServiceProvider = serviceProviderMock.Object;
+
+            return routeBuilder;
+        }
+
+        private static IInlineConstraintResolver GetInlineConstraintResolver()
+        {
+            var services = new ServiceCollection().AddOptions();
+            var serviceProvider = services.BuildServiceProvider();
+            var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
+            return new DefaultInlineConstraintResolver(accessor);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
This adds a property to `TemplateRoute` which allows access to the Optional state of parameters of the target route. Will be used in Glimpse to indicate to the user what parameters are optional vs not. 