### PR TITLE
Expose parsed route so more detailed route is available (i.e. optional state)

### DIFF
--- a/src/Microsoft.AspNet.Routing/Template/RouteTemplate.cs
+++ b/src/Microsoft.AspNet.Routing/Template/RouteTemplate.cs
@@ -37,9 +37,9 @@ namespace Microsoft.AspNet.Routing.Template
             }
         }
 
-        public List<TemplatePart> Parameters { get; private set; }
+        public IList<TemplatePart> Parameters { get; private set; }
 
-        public List<TemplateSegment> Segments { get; private set; }
+        public IList<TemplateSegment> Segments { get; private set; }
 
         private string DebuggerToString()
         {

--- a/src/Microsoft.AspNet.Routing/Template/TemplateRoute.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateRoute.cs
@@ -91,6 +91,11 @@ namespace Microsoft.AspNet.Routing.Template
             get { return _dataTokens; }
         }
 
+        public RouteTemplate ParsedTemplate
+        {
+            get { return _parsedTemplate; }
+        }
+
         public string RouteTemplate
         {
             get { return _routeTemplate; }

--- a/test/Microsoft.AspNet.Routing.Tests/InlineRouteParameterParserTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/InlineRouteParameterParserTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNet.Routing.Template;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.OptionsModel;
 using Xunit;
+using System.Linq;
 
 namespace Microsoft.AspNet.Routing.Tests
 {


### PR DESCRIPTION
This adds a property to `TemplateRoute` which allows access to the `ParsedTemplate` state of the target route. Will be used in Glimpse to indicate to the user what parameters are optional vs not, etc