### PR TITLE
Avoid allocating in TemplateMatcher on failure

### DIFF
--- a/src/Microsoft.AspNet.Routing/Template/RouteTemplate.cs
+++ b/src/Microsoft.AspNet.Routing/Template/RouteTemplate.cs
@@ -41,6 +41,16 @@ namespace Microsoft.AspNet.Routing.Template
 
         public IList<TemplateSegment> Segments { get; private set; }
 
+        public TemplateSegment GetSegment(int index)
+        {
+            if (index < 0)
+            {
+                throw new IndexOutOfRangeException();
+            }
+
+            return index >= Segments.Count ? null : Segments[index];
+        }
+
         private string DebuggerToString()
         {
             return string.Join(SeparatorString, Segments.Select(s => s.DebuggerToString()));

--- a/src/Microsoft.AspNet.Routing/Template/TemplateSegment.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateSegment.cs
@@ -10,12 +10,9 @@ namespace Microsoft.AspNet.Routing.Template
     [DebuggerDisplay("{DebuggerToString()}")]
     public class TemplateSegment
     {
-        private readonly List<TemplatePart> _parts = new List<TemplatePart>();
+        public bool IsSimple => Parts.Count == 1;
 
-        public List<TemplatePart> Parts
-        {
-            get { return _parts; }
-        }
+        public List<TemplatePart> Parts { get; } = new List<TemplatePart>();
 
         internal string DebuggerToString()
         {


### PR DESCRIPTION
This change rejiggers the URL matching algorithm into using a two-pass
system to avoid allocating anything when a URL fails to match a route.

Here's some allocation data based a very simple API site using attribute routing. Allocations of Dictionary and friends for 3000 requests:

**Before**
![image](https://cloud.githubusercontent.com/assets/1430011/10322943/ee94296c-6c34-11e5-9559-86ec95707319.png)

**After**
![image](https://cloud.githubusercontent.com/assets/1430011/10322963/066f9eae-6c35-11e5-8b9e-e8bc81558c10.png)

Notice the sharp decrease in the number of `Dictionary<string, object>` and `RouteValueDictionary` allocations.

This change is worth about 2mb out of 67mb total.