### PR TITLE
Allow defaults to be null when constructiing TemplateMatcher

### DIFF
--- a/src/Microsoft.AspNet.Routing/Template/TemplateMatcher.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateMatcher.cs
@@ -25,11 +25,6 @@ namespace Microsoft.AspNet.Routing.Template
                 throw new ArgumentNullException(nameof(template));
             }
 
-            if (defaults == null)
-            {
-                throw new ArgumentNullException(nameof(defaults));
-            }
-
             Template = template;
             Defaults = defaults ?? RouteValueDictionary.Empty;
         }


### PR DESCRIPTION
The code manages the null value to a default one.
Before c6941e797f1585730b69d088a3b1b0c17ce6afa7 there was a [NotNull] attribute that was enforced but the attribute was not correct, null should be allowed.