### PR TITLE
Optimize RouteValueDictionary, expose concrete type

### DIFF
--- a/src/Microsoft.AspNet.Routing/AttributeRouting/TreeRouter.cs
+++ b/src/Microsoft.AspNet.Routing/AttributeRouting/TreeRouter.cs
@@ -311,8 +311,8 @@ namespace Microsoft.AspNet.Routing.Tree
         }
 
         private static void MergeValues(
-            IDictionary<string, object> destination,
-            IDictionary<string, object> values)
+            RouteValueDictionary destination,
+            RouteValueDictionary values)
         {
             foreach (var kvp in values)
             {
@@ -328,7 +328,7 @@ namespace Microsoft.AspNet.Routing.Tree
 
         private struct TemplateMatch : IEquatable<TemplateMatch>
         {
-            public TemplateMatch(TreeRouteMatchingEntry entry, IDictionary<string, object> values)
+            public TemplateMatch(TreeRouteMatchingEntry entry, RouteValueDictionary values)
             {
                 Entry = entry;
                 Values = values;
@@ -336,7 +336,7 @@ namespace Microsoft.AspNet.Routing.Tree
 
             public TreeRouteMatchingEntry Entry { get; }
 
-            public IDictionary<string, object> Values { get; }
+            public RouteValueDictionary Values { get; }
 
             public override bool Equals(object obj)
             {
@@ -403,7 +403,7 @@ namespace Microsoft.AspNet.Routing.Tree
             //      required values: { id = "5", action = "Buy", Controller = "CoolProducts" }
             //
             //      result: { id = "5", action = "Buy" }
-            var inputValues = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            var inputValues = new RouteValueDictionary();
             foreach (var kvp in context.Values)
             {
                 if (entry.RequiredLinkValues.ContainsKey(kvp.Key))

--- a/src/Microsoft.AspNet.Routing/RouteData.cs
+++ b/src/Microsoft.AspNet.Routing/RouteData.cs
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.Routing
         /// <summary>
         /// Gets the set of values produced by routes on the current routing path.
         /// </summary>
-        public IDictionary<string, object> Values
+        public RouteValueDictionary Values
         {
             get
             {

--- a/src/Microsoft.AspNet.Routing/RouteValueDictionary.cs
+++ b/src/Microsoft.AspNet.Routing/RouteValueDictionary.cs
@@ -18,10 +18,6 @@ namespace Microsoft.AspNet.Routing
         /// </summary>
         internal static readonly IReadOnlyDictionary<string, object> Empty = new RouteValueDictionary();
 
-        private Dictionary<string, object> _dictionary;
-        private readonly PropertyHelper[] _properties;
-        private readonly object _value;
-
         /// <summary>
         /// Creates an empty <see cref="RouteValueDictionary"/>.
         /// </summary>
@@ -47,23 +43,23 @@ namespace Microsoft.AspNet.Routing
             var otherDictionary = values as RouteValueDictionary;
             if (otherDictionary != null)
             {
-                if (otherDictionary._dictionary != null)
+                if (otherDictionary.InnerDictionary != null)
                 {
-                    _dictionary = new Dictionary<string, object>(
-                        otherDictionary._dictionary.Count,
+                    InnerDictionary = new Dictionary<string, object>(
+                        otherDictionary.InnerDictionary.Count,
                         StringComparer.OrdinalIgnoreCase);
 
-                    foreach (var kvp in otherDictionary._dictionary)
+                    foreach (var kvp in otherDictionary.InnerDictionary)
                     {
-                        _dictionary[kvp.Key] = kvp.Value;
+                        InnerDictionary[kvp.Key] = kvp.Value;
                     }
 
                     return;
                 }
-                else if (otherDictionary._properties != null)
+                else if (otherDictionary.Properties != null)
                 {
-                    _properties = otherDictionary._properties;
-                    _value = otherDictionary._value;
+                    Properties = otherDictionary.Properties;
+                    Value = otherDictionary.Value;
                     return;
                 }
                 else
@@ -75,11 +71,11 @@ namespace Microsoft.AspNet.Routing
             var keyValuePairCollection = values as IEnumerable<KeyValuePair<string, object>>;
             if (keyValuePairCollection != null)
             {
-                _dictionary = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                InnerDictionary = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
                 foreach (var kvp in keyValuePairCollection)
                 {
-                    _dictionary[kvp.Key] = kvp.Value;
+                    InnerDictionary[kvp.Key] = kvp.Value;
                 }
 
                 return;
@@ -87,12 +83,18 @@ namespace Microsoft.AspNet.Routing
 
             if (values != null)
             {
-                _properties = PropertyHelper.GetVisibleProperties(values);
-                _value = values;
+                Properties = PropertyHelper.GetVisibleProperties(values);
+                Value = values;
 
                 return;
             }
         }
+
+        private Dictionary<string, object> InnerDictionary { get; set; }
+
+        private PropertyHelper[] Properties { get; }
+
+        private object Value { get; }
 
         /// <inheritdoc />
         public object this[string key]
@@ -117,7 +119,7 @@ namespace Microsoft.AspNet.Routing
                 }
 
                 EnsureWritable();
-                _dictionary[key] = value;
+                InnerDictionary[key] = value;
             }
         }
 
@@ -130,13 +132,7 @@ namespace Microsoft.AspNet.Routing
         public IEqualityComparer<string> Comparer => StringComparer.OrdinalIgnoreCase;
 
         /// <inheritdoc />
-        public int Count
-        {
-            get
-            {
-                return _dictionary?.Count ?? _properties?.Length ?? 0;
-            }
-        }
+        public int Count => InnerDictionary?.Count ?? Properties?.Length ?? 0;
 
         /// <inheritdoc />
         bool ICollection<KeyValuePair<string, object>>.IsReadOnly => false;
@@ -147,7 +143,7 @@ namespace Microsoft.AspNet.Routing
             get
             {
                 EnsureWritable();
-                return _dictionary.Keys;
+                return InnerDictionary.Keys;
             }
         }
 
@@ -156,7 +152,7 @@ namespace Microsoft.AspNet.Routing
             get
             {
                 EnsureWritable();
-                return _dictionary.Keys;
+                return InnerDictionary.Keys;
             }
         }
 
@@ -166,7 +162,7 @@ namespace Microsoft.AspNet.Routing
             get
             {
                 EnsureWritable();
-                return _dictionary.Values;
+                return InnerDictionary.Values;
             }
         }
 
@@ -175,7 +171,7 @@ namespace Microsoft.AspNet.Routing
             get
             {
                 EnsureWritable();
-                return _dictionary.Values;
+                return InnerDictionary.Values;
             }
         }
 
@@ -183,7 +179,7 @@ namespace Microsoft.AspNet.Routing
         void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
         {
             EnsureWritable();
-            ((ICollection<KeyValuePair<string, object>>)_dictionary).Add(item);
+            ((ICollection<KeyValuePair<string, object>>)InnerDictionary).Add(item);
         }
 
         /// <inheritdoc />
@@ -195,21 +191,21 @@ namespace Microsoft.AspNet.Routing
             }
 
             EnsureWritable();
-            _dictionary.Add(key, value);
+            InnerDictionary.Add(key, value);
         }
 
         /// <inheritdoc />
         public void Clear()
         {
             EnsureWritable();
-            _dictionary.Clear();
+            InnerDictionary.Clear();
         }
 
         /// <inheritdoc />
         bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)
         {
             EnsureWritable();
-            return ((ICollection<KeyValuePair<string, object>>)_dictionary).Contains(item);
+            return ((ICollection<KeyValuePair<string, object>>)InnerDictionary).Contains(item);
         }
 
         /// <inheritdoc />
@@ -220,21 +216,21 @@ namespace Microsoft.AspNet.Routing
                 throw new ArgumentNullException(nameof(key));
             }
 
-            if (_dictionary != null)
+            if (InnerDictionary != null)
             {
-                return _dictionary.ContainsKey(key);
+                return InnerDictionary.ContainsKey(key);
             }
-            else if (_properties != null)
+            else if (Properties != null)
             {
-                for (var i = 0; i < _properties.Length; i++)
+                for (var i = 0; i < Properties.Length; i++)
                 {
-                    var property = _properties[i];
+                    var property = Properties[i];
                     if (Comparer.Equals(property.Name, key))
                     {
                         return true;
                     }
                 }
-                
+
                 return false;
             }
             else
@@ -254,7 +250,7 @@ namespace Microsoft.AspNet.Routing
             }
 
             EnsureWritable();
-            ((ICollection<KeyValuePair<string, object>>)_dictionary).CopyTo(array, arrayIndex);
+            ((ICollection<KeyValuePair<string, object>>)InnerDictionary).CopyTo(array, arrayIndex);
         }
 
         /// <inheritdoc />
@@ -279,7 +275,7 @@ namespace Microsoft.AspNet.Routing
         bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
         {
             EnsureWritable();
-            return ((ICollection<KeyValuePair<string, object>>)_dictionary).Remove(item);
+            return ((ICollection<KeyValuePair<string, object>>)InnerDictionary).Remove(item);
         }
 
         /// <inheritdoc />
@@ -291,7 +287,7 @@ namespace Microsoft.AspNet.Routing
             }
 
             EnsureWritable();
-            return _dictionary.Remove(key);
+            return InnerDictionary.Remove(key);
         }
 
         /// <inheritdoc />
@@ -302,18 +298,18 @@ namespace Microsoft.AspNet.Routing
                 throw new ArgumentNullException(nameof(key));
             }
 
-            if (_dictionary != null)
+            if (InnerDictionary != null)
             {
-                return _dictionary.TryGetValue(key, out value);
+                return InnerDictionary.TryGetValue(key, out value);
             }
-            else if (_properties != null)
+            else if (Properties != null)
             {
-                for (var i = 0; i < _properties.Length; i++)
+                for (var i = 0; i < Properties.Length; i++)
                 {
-                    var property = _properties[i];
+                    var property = Properties[i];
                     if (Comparer.Equals(property.Name, key))
                     {
-                        value = property.ValueGetter(_value);
+                        value = property.ValueGetter(Value);
                         return true;
                     }
                 }
@@ -330,18 +326,18 @@ namespace Microsoft.AspNet.Routing
 
         private void EnsureWritable()
         {
-            if (_dictionary == null && _properties == null)
+            if (InnerDictionary == null && Properties == null)
             {
-                _dictionary = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                InnerDictionary = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             }
-            else if (_dictionary == null)
+            else if (InnerDictionary == null)
             {
-                _dictionary = new Dictionary<string, object>(_properties.Length + 1, StringComparer.OrdinalIgnoreCase);
+                InnerDictionary = new Dictionary<string, object>(Properties.Length, StringComparer.OrdinalIgnoreCase);
 
-                for (var i = 0; i < _properties.Length; i++)
+                for (var i = 0; i < Properties.Length; i++)
                 {
-                    var property = _properties[i];
-                    _dictionary.Add(property.Property.Name, property.ValueGetter(_value));
+                    var property = Properties[i];
+                    InnerDictionary.Add(property.Property.Name, property.ValueGetter(Value));
                 }
             }
         }
@@ -357,16 +353,16 @@ namespace Microsoft.AspNet.Routing
             {
                 if (dictionary == null)
                 {
-                    throw new InvalidOperationException();
+                    throw new ArgumentNullException();
                 }
 
                 _dictionary = dictionary;
 
                 Current = default(KeyValuePair<string, object>);
                 _index = -1;
-                _enumerator = _dictionary._dictionary == null ? 
-                    default(Dictionary<string, object>.Enumerator) : 
-                    _dictionary._dictionary.GetEnumerator();
+                _enumerator = _dictionary.InnerDictionary == null ?
+                    default(Dictionary<string, object>.Enumerator) :
+                    _dictionary.InnerDictionary.GetEnumerator();
             }
 
             public KeyValuePair<string, object> Current { get; private set; }
@@ -379,48 +375,37 @@ namespace Microsoft.AspNet.Routing
 
             public bool MoveNext()
             {
-                if (_dictionary?._dictionary != null)
+                if (_dictionary?.InnerDictionary != null)
                 {
                     if (_enumerator.MoveNext())
                     {
                         Current = _enumerator.Current;
                         return true;
                     }
-                    else
-                    {
-                        Current = default(KeyValuePair<string, object>);
-                        return false;
-                    }
                 }
-                else if (_dictionary?._properties != null)
+                else if (_dictionary?.Properties != null)
                 {
-                    if (++_index < _dictionary._properties.Length)
+                    _index++;
+                    if (_index < _dictionary.Properties.Length)
                     {
-                        var property = _dictionary._properties[_index];
-                        var value = property.ValueGetter(_dictionary._value);
+                        var property = _dictionary.Properties[_index];
+                        var value = property.ValueGetter(_dictionary.Value);
                         Current = new KeyValuePair<string, object>(property.Name, value);
                         return true;
                     }
-                    else
-                    {
-                        Current = default(KeyValuePair<string, object>);
-                        return false;
-                    }
                 }
-                else
-                {
-                    Current = default(KeyValuePair<string, object>);
-                    return false;
-                }
+
+                Current = default(KeyValuePair<string, object>);
+                return false;
             }
 
             public void Reset()
             {
                 Current = default(KeyValuePair<string, object>);
                 _index = -1;
-                _enumerator = _dictionary?._dictionary == null ?
+                _enumerator = _dictionary?.InnerDictionary == null ?
                     default(Dictionary<string, object>.Enumerator) :
-                    _dictionary._dictionary.GetEnumerator();
+                    _dictionary.InnerDictionary.GetEnumerator();
             }
         }
     }

--- a/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateBinder.cs
@@ -28,10 +28,9 @@ namespace Microsoft.AspNet.Routing.Template
         }
 
         // Step 1: Get the list of values we're going to try to use to match and generate this URI
-        public TemplateValuesResult GetValues(IDictionary<string, object> ambientValues,
-                                                             IDictionary<string, object> values)
+        public TemplateValuesResult GetValues(RouteValueDictionary ambientValues, RouteValueDictionary values)
         {
-            var context = new TemplateBindingContext(_defaults, values);
+            var context = new TemplateBindingContext(_defaults);
 
             // Find out which entries in the URI are valid for the URI we want to generate.
             // If the URI had ordered parameters a="1", b="2", c="3" and the new values
@@ -171,7 +170,7 @@ namespace Microsoft.AspNet.Routing.Template
         }
 
         // Step 2: If the route is a match generate the appropriate URI
-        public string BindValues(IDictionary<string, object> acceptedValues)
+        public string BindValues(RouteValueDictionary acceptedValues)
         {
             var context = new UriBuildingContext();
 
@@ -355,15 +354,8 @@ namespace Microsoft.AspNet.Routing.Template
             private readonly RouteValueDictionary _acceptedValues;
             private readonly RouteValueDictionary _filters;
 
-            public TemplateBindingContext(
-                IReadOnlyDictionary<string, object> defaults,
-                IDictionary<string, object> values)
+            public TemplateBindingContext(IReadOnlyDictionary<string, object> defaults)
             {
-                if (values == null)
-                {
-                    throw new ArgumentNullException(nameof(values));
-                }
-
                 _defaults = defaults;
 
                 _acceptedValues = new RouteValueDictionary();

--- a/src/Microsoft.AspNet.Routing/Template/TemplateMatcher.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateMatcher.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Routing.Template
 
         public RouteTemplate Template { get; private set; }
 
-        public IDictionary<string, object> Match(PathString path)
+        public RouteValueDictionary Match(PathString path)
         {
             var i = 0;
             var pathTokenizer = new PathTokenizer(path);

--- a/src/Microsoft.AspNet.Routing/Template/TemplateRoute.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateRoute.cs
@@ -317,8 +317,8 @@ namespace Microsoft.AspNet.Routing.Template
         }
 
         private static void MergeValues(
-            IDictionary<string, object> destination,
-            IDictionary<string, object> values)
+            RouteValueDictionary destination,
+            RouteValueDictionary values)
         {
             foreach (var kvp in values)
             {

--- a/src/Microsoft.AspNet.Routing/Template/TemplateValuesResult.cs
+++ b/src/Microsoft.AspNet.Routing/Template/TemplateValuesResult.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-
 namespace Microsoft.AspNet.Routing.Template
 {
     /// <summary>
@@ -13,7 +11,7 @@ namespace Microsoft.AspNet.Routing.Template
         /// <summary>
         /// The set of values that will appear in the URL.
         /// </summary>
-        public IDictionary<string, object> AcceptedValues { get; set; }
+        public RouteValueDictionary AcceptedValues { get; set; }
 
         /// <summary>
         /// The set of values that that were supplied for URL generation.
@@ -26,6 +24,6 @@ namespace Microsoft.AspNet.Routing.Template
         /// Implicit (ambient) values which are invalidated due to changes in values lexically earlier in the
         /// route template are excluded from this set.
         /// </remarks>
-        public IDictionary<string, object> CombinedValues { get; set; }
+        public RouteValueDictionary CombinedValues { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.Routing/VirtualPathContext.cs
+++ b/src/Microsoft.AspNet.Routing/VirtualPathContext.cs
@@ -28,16 +28,16 @@ namespace Microsoft.AspNet.Routing
             RouteName = routeName;
         }
 
-        public string RouteName { get; private set; }
+        public string RouteName { get; }
 
         public IDictionary<string, object> ProvidedValues { get; set; }
 
-        public RouteValueDictionary AmbientValues { get; private set; }
+        public RouteValueDictionary AmbientValues { get; }
 
-        public HttpContext Context { get; private set; }
+        public HttpContext Context { get; }
 
         public bool IsBound { get; set; }
 
-        public RouteValueDictionary Values { get; private set; }
+        public RouteValueDictionary Values { get; }
     }
 }

--- a/src/Microsoft.AspNet.Routing/VirtualPathContext.cs
+++ b/src/Microsoft.AspNet.Routing/VirtualPathContext.cs
@@ -8,17 +8,19 @@ namespace Microsoft.AspNet.Routing
 {
     public class VirtualPathContext
     {
-        public VirtualPathContext(HttpContext httpContext,
-                                  IDictionary<string, object> ambientValues,
-                                  IDictionary<string, object> values)
+        public VirtualPathContext(
+            HttpContext httpContext,
+            RouteValueDictionary ambientValues,
+            RouteValueDictionary values)
             : this(httpContext, ambientValues, values, null)
         {
         }
 
-        public VirtualPathContext(HttpContext context,
-                                  IDictionary<string, object> ambientValues,
-                                  IDictionary<string, object> values,
-                                  string routeName)
+        public VirtualPathContext(
+            HttpContext context,
+            RouteValueDictionary ambientValues,
+            RouteValueDictionary values,
+            string routeName)
         {
             Context = context;
             AmbientValues = ambientValues;
@@ -30,12 +32,12 @@ namespace Microsoft.AspNet.Routing
 
         public IDictionary<string, object> ProvidedValues { get; set; }
 
-        public IDictionary<string, object> AmbientValues { get; private set; }
+        public RouteValueDictionary AmbientValues { get; private set; }
 
         public HttpContext Context { get; private set; }
 
         public bool IsBound { get; set; }
 
-        public IDictionary<string, object> Values { get; private set; }
+        public RouteValueDictionary Values { get; private set; }
     }
 }

--- a/src/Microsoft.AspNet.Routing/VirtualPathData.cs
+++ b/src/Microsoft.AspNet.Routing/VirtualPathData.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.AspNet.Http;
 
 namespace Microsoft.AspNet.Routing
@@ -13,8 +12,6 @@ namespace Microsoft.AspNet.Routing
     /// </summary>
     public class VirtualPathData
     {
-        private readonly IDictionary<string, object> _dataTokens;
-
         /// <summary>
         ///  Initializes a new instance of the <see cref="VirtualPathData"/> class.
         /// </summary>
@@ -34,7 +31,7 @@ namespace Microsoft.AspNet.Routing
         public VirtualPathData(
             IRouter router,
             string virtualPath,
-            IDictionary<string, object> dataTokens)
+            RouteValueDictionary dataTokens)
             : this(router, CreatePathString(virtualPath), dataTokens)
         {
         }
@@ -48,7 +45,7 @@ namespace Microsoft.AspNet.Routing
         public VirtualPathData(
             IRouter router,
             PathString virtualPath,
-            IDictionary<string, object> dataTokens)
+            RouteValueDictionary dataTokens)
         {
             if (router == null)
             {
@@ -57,24 +54,13 @@ namespace Microsoft.AspNet.Routing
 
             Router = router;
             VirtualPath = virtualPath;
-
-            _dataTokens = new RouteValueDictionary();
-            if (dataTokens != null)
-            {
-                foreach (var dataToken in dataTokens)
-                {
-                    _dataTokens.Add(dataToken.Key, dataToken.Value);
-                }
-            }
+            DataTokens = dataTokens;
         }
 
         /// <summary>
         /// Gets the collection of custom values for the <see cref="Router"/>.
         /// </summary>
-        public IDictionary<string, object> DataTokens
-        {
-            get { return _dataTokens; }
-        }
+        public RouteValueDictionary DataTokens { get; }
 
         /// <summary>
         /// Gets or sets the <see cref="IRouter"/> that was used to generate the URL.

--- a/src/Microsoft.AspNet.Routing/VirtualPathData.cs
+++ b/src/Microsoft.AspNet.Routing/VirtualPathData.cs
@@ -12,13 +12,15 @@ namespace Microsoft.AspNet.Routing
     /// </summary>
     public class VirtualPathData
     {
+        private RouteValueDictionary _dataTokens;
+
         /// <summary>
         ///  Initializes a new instance of the <see cref="VirtualPathData"/> class.
         /// </summary>
         /// <param name="router">The object that is used to generate the URL.</param>
         /// <param name="virtualPath">The generated URL.</param>
         public VirtualPathData(IRouter router, string virtualPath)
-            : this(router, virtualPath, dataTokens: new RouteValueDictionary())
+            : this(router, virtualPath, dataTokens: null)
         {
         }
 
@@ -54,13 +56,24 @@ namespace Microsoft.AspNet.Routing
 
             Router = router;
             VirtualPath = virtualPath;
-            DataTokens = dataTokens;
+            _dataTokens = dataTokens == null ? null : new RouteValueDictionary(dataTokens);
         }
 
         /// <summary>
         /// Gets the collection of custom values for the <see cref="Router"/>.
         /// </summary>
-        public RouteValueDictionary DataTokens { get; }
+        public RouteValueDictionary DataTokens
+        {
+            get
+            {
+                if (_dataTokens == null)
+                {
+                    _dataTokens = new RouteValueDictionary();
+                }
+
+                return _dataTokens;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the <see cref="IRouter"/> that was used to generate the URL.

--- a/src/Microsoft.AspNet.Routing/project.json
+++ b/src/Microsoft.AspNet.Routing/project.json
@@ -9,21 +9,25 @@
     "warningsAsErrors": true,
     "keyFile": "../../tools/Key.snk"
   },
-    "dependencies": {
-        "Microsoft.AspNet.Http.Extensions": "1.0.0-*",
-        "Microsoft.AspNet.Routing.DecisionTree.Sources": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
-        "Microsoft.Extensions.HashCodeCombiner.Sources": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
-        "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
-        "Microsoft.Extensions.OptionsModel": "1.0.0-*"
+  "dependencies": {
+    "Microsoft.AspNet.Http.Extensions": "1.0.0-*",
+    "Microsoft.AspNet.Routing.DecisionTree.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
     },
+    "Microsoft.Extensions.HashCodeCombiner.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    },
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
+    "Microsoft.Extensions.OptionsModel": "1.0.0-*",
+    "Microsoft.Extensions.PropertyHelper.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    }
+  },
   "frameworks": {
-    "net451": {},
+    "net451": { },
     "dotnet5.4": {
       "dependencies": {
         "System.Text.RegularExpressions": "4.0.11-*"

--- a/test/Microsoft.AspNet.Routing.Tests/RouteValueDictionaryTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/RouteValueDictionaryTests.cs
@@ -165,7 +165,11 @@ namespace Microsoft.AspNet.Routing.Tests
 
             // Act & Assert
             ExceptionAssert.Throws<ArgumentException>(
-                () => new RouteValueDictionary(obj),
+                () =>
+                {
+                    var dictionary = new RouteValueDictionary(obj);
+                    dictionary.Add("Hi", "There");
+                },
                 expected);
         }
 

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         public void Binding_WithEmptyAndNull_DefaultValues(
             string template,
             IReadOnlyDictionary<string, object> defaults,
-            IDictionary<string, object> values,
+            RouteValueDictionary values,
             string expected)
         {
             // Arrange
@@ -284,8 +284,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         public void GetVirtualPathWithMultiSegmentWithOptionalParam(
             string template,
             IReadOnlyDictionary<string, object> defaults,
-            IDictionary<string, object> ambientValues,
-            IDictionary<string, object> values,
+            RouteValueDictionary ambientValues,
+            RouteValueDictionary values,
             string expected)
         {
             // Arrange
@@ -1086,8 +1086,8 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         private static void RunTest(
             string template,
             IReadOnlyDictionary<string, object> defaults,
-            IDictionary<string, object> ambientValues,
-            IDictionary<string, object> values,
+            RouteValueDictionary ambientValues,
+            RouteValueDictionary values,
             string expected)
         {
             // Arrange

--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateRouteTest.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateRouteTest.cs
@@ -1658,8 +1658,8 @@ namespace Microsoft.AspNet.Routing.Template
         }
 
         private static VirtualPathContext CreateVirtualPathContext(
-            IDictionary<string, object> values,
-            IDictionary<string, object> ambientValues)
+            RouteValueDictionary values,
+            RouteValueDictionary ambientValues)
         {
             var context = new Mock<HttpContext>(MockBehavior.Strict);
             context.Setup(m => m.RequestServices.GetService(typeof(ILoggerFactory)))


### PR DESCRIPTION
This change optimizes allocations by RouteValueDictionary based on usage.

First, implement a struct Enumerator, and expose the concrete RVD type
from all extensibility points. We wanted to try and decouple this code
from RVD originally and use IDictionary everywhere. After doing that we've
found that it allocates an unacceptable number of enumerators.

Secondly, optimize copies of RVD for the case where you're copying an RVC
to another (common case). When doing this we can copy the count to get the
right capacity, and copy the entries without allocating an enumerator.

Lastly, optimize RVD for the case where it's a wrapper around a poco
object. We 'upgrade' to a writable full dictionary if you try to write to
it, or call one of a number of APIs that are uncommonly used. We could
produce optimized versions of things like `Keys` and `CopyTo`.