### PR TITLE
Create DoesNotContainConstraint.cs

### DIFF
--- a/src/Microsoft.AspNet.Routing/Constraints/DoesNotContainConstraint.cs
+++ b/src/Microsoft.AspNet.Routing/Constraints/DoesNotContainConstraint.cs
@@ -1,0 +1,44 @@
+public class DoesNotContainConstraint : IRouteConstraint
+    {
+        private readonly string m_Substring;
+
+        public DoesNotContainConstraint(string substring)
+        {
+            m_Substring = substring;
+        }
+
+        public bool Match(HttpContext httpContext, IRouter route, string routeKey, IDictionary<string, object> values, RouteDirection routeDirection)
+        {
+            if (httpContext == null)
+            {
+                throw new ArgumentNullException(nameof(httpContext));
+            }
+
+            if (route == null)
+            {
+                throw new ArgumentNullException(nameof(route));
+            }
+
+            if (routeKey == null)
+            {
+                throw new ArgumentNullException(nameof(routeKey));
+            }
+
+            if (values == null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
+            object routeValue;
+
+            if (values.TryGetValue(routeKey, out routeValue)
+                && routeValue != null)
+            {
+                string parameterValueString = Convert.ToString(routeValue, CultureInfo.InvariantCulture);
+
+                return !parameterValueString.Contains(m_Substring);
+            }
+
+            return true;
+        }
+    }


### PR DESCRIPTION
There is a common scenario when you would like to exclude some paths from the route. E.g. in a SPA app you generally want to map all the /api routes to controllers, and all other non static files to Home\Index so that client will handle the urls in the browser (e.g. angular). It can be done like that: "template: {*url}". Now the drawback is that e.g. lib/someCode.js will also fall for this route if the static file does not exist. So in case you have a problem you won't see a 404, but rather it will return your main view which is a bit weird. To avoid that situation we can exclude the routes that contain "." e.g. It is possible to do with regex, but that's not so efficient and regex is rather nontrivial to achieve it. So it will be good to have the exclusion constraint (maybe inclusion as well) that can do it simply. Perhaps the name is not the best (DoesNotContainConstraint), but it can be renamed to anything better.