### PR TITLE
Reduce allocation in URL generation

### DIFF
--- a/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Template/TemplateBinderTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         [MemberData(nameof(EmptyAndNullDefaultValues))]
         public void Binding_WithEmptyAndNull_DefaultValues(
             string template,
-            IReadOnlyDictionary<string, object> defaults,
+            RouteValueDictionary defaults,
             RouteValueDictionary values,
             string expected)
         {
@@ -255,7 +255,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
         [MemberData(nameof(OptionalParamValues))]
         public void GetVirtualPathWithMultiSegmentWithOptionalParam(
             string template,
-            IReadOnlyDictionary<string, object> defaults,
+            RouteValueDictionary defaults,
             RouteValueDictionary ambientValues,
             RouteValueDictionary values,
             string expected)
@@ -1083,7 +1083,7 @@ namespace Microsoft.AspNet.Routing.Template.Tests
 
         private static void RunTest(
             string template,
-            IReadOnlyDictionary<string, object> defaults,
+            RouteValueDictionary defaults,
             RouteValueDictionary ambientValues,
             RouteValueDictionary values,
             string expected,

--- a/test/Microsoft.AspNet.Routing.Tests/Tree/TreeRouterTest.cs
+++ b/test/Microsoft.AspNet.Routing.Tests/Tree/TreeRouterTest.cs
@@ -1571,9 +1571,14 @@ namespace Microsoft.AspNet.Routing.Tree
             var entry = new TreeRouteLinkGenerationEntry();
             entry.Template = TemplateParser.Parse(template);
 
-            var defaults = entry.Template.Parameters
-                .Where(p => p.DefaultValue != null)
-                .ToDictionary(p => p.Name, p => p.DefaultValue);
+            var defaults = new RouteValueDictionary();
+            foreach (var parameter in entry.Template.Parameters)
+            {
+                if (parameter.DefaultValue != null)
+                {
+                    defaults.Add(parameter.Name, parameter.DefaultValue);
+                }
+            }
 
             var constraintBuilder = new RouteConstraintBuilder(CreateConstraintResolver(), template);
             foreach (var parameter in entry.Template.Parameters)


### PR DESCRIPTION
This change optimizes our a per-operation dictionary that really can just
be cached for the whole app's lifetime.