### PR TITLE
Perf: Save ~7 object allocations when resolving an action URL 

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Internal/LinkGenerationDecisionTree.cs
+++ b/src/Microsoft.AspNetCore.Routing/Internal/LinkGenerationDecisionTree.cs
@@ -22,10 +22,16 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
         public IList<LinkGenerationMatch> GetMatches(VirtualPathContext context)
         {
-            var results = new List<LinkGenerationMatch>();
-            Walk(results, context, _root, isFallbackPath: false);
-            results.Sort(LinkGenerationMatchComparer.Instance);
-            return results;
+            // Perf: Avoid allocation for List if there aren't any Matches or Criteria
+            if (_root.Matches.Count > 0 || _root.Criteria.Count > 0)
+            {
+                var results = new List<LinkGenerationMatch>();
+                Walk(results, context, _root, isFallbackPath: false);
+                results.Sort(LinkGenerationMatchComparer.Instance);
+                return results;
+            }
+
+            return null;            
         }
 
         // We need to recursively walk the decision tree based on the provided route data

--- a/src/Microsoft.AspNetCore.Routing/RouteConstraintMatcher.cs
+++ b/src/Microsoft.AspNetCore.Routing/RouteConstraintMatcher.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Routing
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            if (constraints == null)
+            if (constraints == null || constraints.Count == 0)
             {
                 return true;
             }

--- a/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
+++ b/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
@@ -138,9 +138,14 @@ namespace Microsoft.AspNetCore.Routing.Tree
             // order. We just need to iterate them and use the first one that can generate a link.
             var matches = _linkGenerationTree.GetMatches(context);
 
-            foreach (var match in matches)
+            if (matches == null)
             {
-                var path = GenerateVirtualPath(context, match.Entry);
+                return null;
+            }
+
+            for (var i = 0; i < matches.Count; i++)
+            {
+                var path = GenerateVirtualPath(context, matches[i].Entry);
                 if (path != null)
                 {
                     return path;


### PR DESCRIPTION
aspnet/Performance#57 
  The effort is to save memory allocations as part of building the action URLs  for form/link tag helpers. The aspnet/Performance#57 has detailed analysis.