### PR TITLE
[Perf] Avoid Linq method and save its related allocations in TreeRouter

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Template/RouteTemplate.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/RouteTemplate.cs
@@ -59,5 +59,24 @@ namespace Microsoft.AspNetCore.Routing.Template
         {
             return string.Join(SeparatorString, Segments.Select(s => s.DebuggerToString()));
         }
+
+        /// <summary>
+        /// Gets the parameter matching the given name.
+        /// </summary>
+        /// <param name="name">The name of the parameter to match.</param>
+        /// <returns>The matching parameter or <c>null</c> if no parameter matches the given name.</returns>
+        public TemplatePart GetParameter(string name)
+        {
+            for (var i = 0; i < Parameters.Count; i++)
+            {
+                var parameter = Parameters[i];
+                if (string.Equals(parameter.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return parameter;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
+++ b/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
@@ -386,8 +386,7 @@ namespace Microsoft.AspNetCore.Routing.Tree
             {
                 if (entry.RequiredLinkValues.ContainsKey(kvp.Key))
                 {
-                    var parameter = entry.Template.Parameters
-                        .FirstOrDefault(p => string.Equals(p.Name, kvp.Key, StringComparison.OrdinalIgnoreCase));
+                    var parameter = entry.Template.GetParameter(kvp.Key);
 
                     if (parameter == null)
                     {


### PR DESCRIPTION
TreeRouter.GenerateVirtualPath() has the following expression

var parameter = entry.Template.Parameters
             .FirstOrDefault(p => string.Equals(p.Name, kvp.Key, StringComparison.OrdinalIgnoreCase));

that is resulting in 3 allocations
1. Delegate for FirstOrDefault (System.Func)
2. Closure for TreeRouter
3. Enumerator for Parameters 
This expression is used in a loop for each of the Route values. 

By removing this Linq expression, there is 3.5% saving in total number of allocations and 2.5% in total number of bytes allocated. 

The measurements are against Performance/BasicViews test app with the View having 6 action links . Each of these actions href is generated using TagHelpers with **attribute routing**. And loadtest is run against the app with the following setting

loadtest --rps 100 -n 3000 -k <URL>
