### PR TITLE
Remove dictionary alloc in routing

### DIFF
--- a/Routing.sln
+++ b/Routing.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24711.0
+VisualStudioVersion = 14.0.25029.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0E966C37-7334-4D96-AAF6-9F49FBD166E3}"
 EndProject
@@ -70,7 +70,6 @@ Global
 		{ABD5AA59-6000-4A3D-A54F-4B636F725AE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ABD5AA59-6000-4A3D-A54F-4B636F725AE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ABD5AA59-6000-4A3D-A54F-4B636F725AE8}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{ABD5AA59-6000-4A3D-A54F-4B636F725AE8}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{ABD5AA59-6000-4A3D-A54F-4B636F725AE8}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{ABD5AA59-6000-4A3D-A54F-4B636F725AE8}.Debug|x86.Build.0 = Debug|Any CPU
 		{ABD5AA59-6000-4A3D-A54F-4B636F725AE8}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/Microsoft.AspNetCore.Routing/RouteBase.cs
+++ b/src/Microsoft.AspNetCore.Routing/RouteBase.cs
@@ -82,9 +82,8 @@ namespace Microsoft.AspNetCore.Routing
             EnsureLoggers(context.HttpContext);
 
             var requestPath = context.HttpContext.Request.Path;
-            var values = _matcher.Match(requestPath);
 
-            if (values == null)
+            if (!_matcher.TryMatch(requestPath, context.RouteData.Values))
             {
                 // If we got back a null value set, that means the URI did not match
                 return TaskCache.CompletedTask;
@@ -95,11 +94,6 @@ namespace Microsoft.AspNetCore.Routing
             if (DataTokens.Count > 0)
             {
                 MergeValues(context.RouteData.DataTokens, DataTokens);
-            }
-
-            if (values.Count > 0)
-            {
-                MergeValues(context.RouteData.Values, values);
             }
 
             if (!RouteConstraintMatcher.Match(

--- a/src/Microsoft.AspNetCore.Routing/Template/TemplateMatcher.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/TemplateMatcher.cs
@@ -65,6 +65,11 @@ namespace Microsoft.AspNetCore.Routing.Template
 
         public bool TryMatch(PathString path, RouteValueDictionary values)
         {
+            if (values == null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
             var i = 0;
             var pathTokenizer = new PathTokenizer(path);
 

--- a/src/Microsoft.AspNetCore.Routing/Template/TemplateMatcher.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/TemplateMatcher.cs
@@ -63,7 +63,7 @@ namespace Microsoft.AspNetCore.Routing.Template
 
         public RouteTemplate Template { get; }
 
-        public RouteValueDictionary Match(PathString path)
+        public bool TryMatch(PathString path, RouteValueDictionary values)
         {
             var i = 0;
             var pathTokenizer = new PathTokenizer(path);
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Routing.Template
                 {
                     // If pathSegment is null, then we're out of route segments. All we can match is the empty
                     // string.
-                    return null;
+                    return false;
                 }
                 else if (routeSegment.IsSimple && routeSegment.Parts[0].IsLiteral)
                 {
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Routing.Template
                     var part = routeSegment.Parts[0];
                     if (!requestSegment.Equals(part.Text, StringComparison.OrdinalIgnoreCase))
                     {
-                        return null;
+                        return false;
                     }
                 }
                 else if (routeSegment.IsSimple && routeSegment.Parts[0].IsCatchAll)
@@ -111,7 +111,7 @@ namespace Microsoft.AspNetCore.Routing.Template
                         !part.IsOptional)
                     {
                         // There's no value for this parameter, the route can't match.
-                        return null;
+                        return false;
                     }
                 }
                 else
@@ -134,14 +134,14 @@ namespace Microsoft.AspNetCore.Routing.Template
                 {
                     // If the segment is a complex segment, it MUST contain literals, and we've parsed the full
                     // path so far, so it can't match.
-                    return null;
+                    return false;
                 }
 
                 var part = routeSegment.Parts[0];
                 if (part.IsLiteral)
                 {
                     // If the segment is a simple literal - which need the URL to provide a value, so we don't match.
-                    return null;
+                    return false;
                 }
 
                 if (part.IsCatchAll)
@@ -158,12 +158,11 @@ namespace Microsoft.AspNetCore.Routing.Template
                 if (!_hasDefaultValue[i] && !part.IsOptional)
                 {
                     // There's no default for this (non-optional) parameter so it can't match.
-                    return null;
+                    return false;
                 }
             }
 
             // At this point we've very likely got a match, so start capturing values for real.
-            var values = new RouteValueDictionary();
 
             i = 0;
             foreach (var requestSegment in pathTokenizer)
@@ -177,12 +176,12 @@ namespace Microsoft.AspNetCore.Routing.Template
                     var captured = requestSegment.Buffer.Substring(requestSegment.Offset);
                     if (captured.Length > 0)
                     {
-                        values.Add(part.Name, captured);
+                        values[part.Name] = captured;
                     }
                     else
                     {
                         // It's ok for a catch-all to produce a null value, so we don't check _hasDefaultValue.
-                        values.Add(part.Name, _defaultValues[i]);
+                        values[part.Name] =_defaultValues[i];
                     }
 
                     // A catch-all has to be the last part, so we're done.
@@ -195,13 +194,13 @@ namespace Microsoft.AspNetCore.Routing.Template
                     var part = routeSegment.Parts[0];
                     if (requestSegment.Length > 0)
                     {
-                        values.Add(part.Name, requestSegment.ToString());
+                        values[part.Name] = requestSegment.ToString();
                     }
                     else
                     {
                         if (_hasDefaultValue[i])
                         {
-                            values.Add(part.Name, _defaultValues[i]);
+                            values[part.Name] = _defaultValues[i];
                         }
                     }
                 }
@@ -209,7 +208,7 @@ namespace Microsoft.AspNetCore.Routing.Template
                 {
                     if (!MatchComplexSegment(routeSegment, requestSegment.ToString(), Defaults, values))
                     {
-                        return null;
+                        return false;
                     }
                 }
             }
@@ -228,7 +227,12 @@ namespace Microsoft.AspNetCore.Routing.Template
                 // It's ok for a catch-all to produce a null value
                 if (_hasDefaultValue[i] || part.IsCatchAll)
                 {
-                    values.Add(part.Name, _defaultValues[i]);
+                    // Don't trounce an existing value with a null.
+                    var defaultValue = _defaultValues[i];
+                    if (defaultValue != null || !values.ContainsKey(part.Name))
+                    {
+                        values[part.Name] = _defaultValues[i];
+                    }
                 }
             }
 
@@ -241,7 +245,7 @@ namespace Microsoft.AspNetCore.Routing.Template
                 }
             }
 
-            return values;
+            return true;
         }
 
         private bool MatchComplexSegment(

--- a/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
+++ b/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
@@ -166,36 +166,37 @@ namespace Microsoft.AspNetCore.Routing.Tree
 
                 var treeEnumerator = new TreeEnumerator(root, tokenizer);
 
+                // Create a snapshot before processing the route. We'll restore this snapshot before running each
+                // to restore the state. This is likely an "empty" snapshot, which doesn't allocate.
+                var snapshot = context.RouteData.PushState(null, null, null);
+
                 while (treeEnumerator.MoveNext())
                 {
                     var node = treeEnumerator.Current;
                     foreach (var item in node.Matches)
                     {
-                        var values = item.TemplateMatcher.Match(context.HttpContext.Request.Path);
-                        if (values == null)
+                        if (!item.TemplateMatcher.TryMatch(context.HttpContext.Request.Path, context.RouteData.Values))
                         {
                             continue;
                         }
 
-                        var match = new TemplateMatch(item, values);
-                        var snapshot = context.RouteData.PushState(match.Entry.Target, match.Values, dataTokens: null);
-
                         try
                         {
                             if (!RouteConstraintMatcher.Match(
-                                    match.Entry.Constraints,
-                                    context.RouteData.Values,
-                                    context.HttpContext,
-                                    this,
-                                    RouteDirection.IncomingRequest,
-                                    _constraintLogger))
+                                item.Constraints,
+                                context.RouteData.Values,
+                                context.HttpContext,
+                                this,
+                                RouteDirection.IncomingRequest,
+                                _constraintLogger))
                             {
                                 continue;
                             }
 
-                            _logger.MatchedRoute(match.Entry.RouteName, match.Entry.RouteTemplate.TemplateText);
+                            _logger.MatchedRoute(item.RouteName, item.RouteTemplate.TemplateText);
 
-                            await match.Entry.Target.RouteAsync(context);
+                            context.RouteData.Routers.Add(item.Target);
+                            await item.Target.RouteAsync(context);
                             if (context.Handler != null)
                             {
                                 return;

--- a/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
+++ b/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
@@ -168,7 +168,7 @@ namespace Microsoft.AspNetCore.Routing.Tree
 
                 // Create a snapshot before processing the route. We'll restore this snapshot before running each
                 // to restore the state. This is likely an "empty" snapshot, which doesn't allocate.
-                var snapshot = context.RouteData.PushState(null, null, null);
+                var snapshot = context.RouteData.PushState(router: null, values: null, dataTokens: null);
 
                 while (treeEnumerator.MoveNext())
                 {

--- a/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
+++ b/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
@@ -316,54 +316,6 @@ namespace Microsoft.AspNetCore.Routing.Tree
             }
         }
 
-        private struct TemplateMatch : IEquatable<TemplateMatch>
-        {
-            public TemplateMatch(TreeRouteMatchingEntry entry, RouteValueDictionary values)
-            {
-                Entry = entry;
-                Values = values;
-            }
-
-            public TreeRouteMatchingEntry Entry { get; }
-
-            public RouteValueDictionary Values { get; }
-
-            public override bool Equals(object obj)
-            {
-                if (obj is TemplateMatch)
-                {
-                    return Equals((TemplateMatch)obj);
-                }
-
-                return false;
-            }
-
-            public bool Equals(TemplateMatch other)
-            {
-                return
-                    object.ReferenceEquals(Entry, other.Entry) &&
-                    object.ReferenceEquals(Values, other.Values);
-            }
-
-            public override int GetHashCode()
-            {
-                var hash = new HashCodeCombiner();
-                hash.Add(Entry);
-                hash.Add(Values);
-                return hash.CombinedHash;
-            }
-
-            public static bool operator ==(TemplateMatch left, TemplateMatch right)
-            {
-                return left.Equals(right);
-            }
-
-            public static bool operator !=(TemplateMatch left, TemplateMatch right)
-            {
-                return !left.Equals(right);
-            }
-        }
-
         private VirtualPathData GetVirtualPathForNamedRoute(VirtualPathContext context)
         {
             TreeRouteLinkGenerationEntry entry;

--- a/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateMatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateMatcherTests.cs
@@ -19,14 +19,16 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{controller}/{action}/{id}");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var match = matcher.Match("/Bank/DoAction/123");
+            var match = matcher.TryMatch("/Bank/DoAction/123", values);
 
             // Assert
-            Assert.NotNull(match);
-            Assert.Equal("Bank", match["controller"]);
-            Assert.Equal("DoAction", match["action"]);
-            Assert.Equal("123", match["id"]);
+            Assert.True(match);
+            Assert.Equal("Bank", values["controller"]);
+            Assert.Equal("DoAction", values["action"]);
+            Assert.Equal("123", values["id"]);
         }
 
         [Fact]
@@ -35,11 +37,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{controller}/{action}/{id}");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var match = matcher.Match("/Bank/DoAction");
+            var match = matcher.TryMatch("/Bank/DoAction", values);
 
             // Assert
-            Assert.Null(match);
+            Assert.False(match);
         }
 
         [Fact]
@@ -48,13 +52,15 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{controller}/{action}/{id}", new { id = "default id" });
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/Bank/DoAction");
+            var match = matcher.TryMatch("/Bank/DoAction", values);
 
             // Assert
-            Assert.Equal("Bank", rd["controller"]);
-            Assert.Equal("DoAction", rd["action"]);
-            Assert.Equal("default id", rd["id"]);
+            Assert.Equal("Bank", values["controller"]);
+            Assert.Equal("DoAction", values["action"]);
+            Assert.Equal("default id", values["id"]);
         }
 
         [Fact]
@@ -63,11 +69,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{controller}/{action}/{id}", new { id = "default id" });
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/Bank");
+            var match = matcher.TryMatch("/Bank", values);
 
             // Assert
-            Assert.Null(rd);
+            Assert.False(match);
         }
 
         [Fact]
@@ -76,12 +84,14 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("moo/{p1}/bar/{p2}", new { p2 = "default p2" });
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/moo/111/bar/222");
+            var match = matcher.TryMatch("/moo/111/bar/222", values);
 
             // Assert
-            Assert.Equal("111", rd["p1"]);
-            Assert.Equal("222", rd["p2"]);
+            Assert.Equal("111", values["p1"]);
+            Assert.Equal("222", values["p2"]);
         }
 
         [Fact]
@@ -90,12 +100,14 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("moo/{p1}/bar/{p2}", new { p2 = "default p2" });
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/moo/111/bar/");
+            var match = matcher.TryMatch("/moo/111/bar/", values);
 
             // Assert
-            Assert.Equal("111", rd["p1"]);
-            Assert.Equal("default p2", rd["p2"]);
+            Assert.Equal("111", values["p1"]);
+            Assert.Equal("default p2", values["p2"]);
         }
 
         [Theory]
@@ -110,11 +122,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher(template);
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match(path);
+            var match = matcher.TryMatch(path, values);
 
             // Assert
-            Assert.NotNull(rd);
+            Assert.True(match);
         }
 
         [Theory]
@@ -140,17 +154,19 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher(template);
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match(path);
+            var match = matcher.TryMatch(path, values);
 
             // Assert
             if (p1 != null)
             {
-                Assert.Equal(p1, rd["p1"]);
+                Assert.Equal(p1, values["p1"]);
             }
             if (p2 != null)
             {
-                Assert.Equal(p2, rd["p2"]);
+                Assert.Equal(p2, values["p2"]);
             }
         }
 
@@ -172,20 +188,22 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher(template);
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match(path);
+            var match = matcher.TryMatch(path, values);
 
             // Assert
-            Assert.Equal(p1, rd["p1"]);
+            Assert.Equal(p1, values["p1"]);
 
             if (p2 != null)
             {
-                Assert.Equal(p2, rd["p2"]);
+                Assert.Equal(p2, values["p2"]);
             }
 
             if (p3 != null)
             {
-                Assert.Equal(p3, rd["p3"]);
+                Assert.Equal(p3, values["p3"]);
             }
         }
 
@@ -207,11 +225,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher(template);
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match(path);
+            var match = matcher.TryMatch(path, values);
 
             // Assert
-            Assert.Null(rd);
+            Assert.False(match);
         }
 
         [Fact]
@@ -220,12 +240,14 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("moo/bar");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/moo/bar");
+            var match = matcher.TryMatch("/moo/bar", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(0, rd.Count);
+            Assert.True(match);
+            Assert.Empty(values);
         }
 
         [Fact]
@@ -234,11 +256,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("moo/bars");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/moo/bar");
+            var match = matcher.TryMatch("/moo/bar", values);
 
             // Assert
-            Assert.Null(rd);
+            Assert.False(match);
         }
 
         [Fact]
@@ -247,12 +271,14 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("moo/bar");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/moo/bar/");
+            var match = matcher.TryMatch("/moo/bar/", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(0, rd.Count);
+            Assert.True(match);
+            Assert.Empty(values);
         }
 
         [Fact]
@@ -261,12 +287,14 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("moo/bar/");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/moo/bar");
+            var match = matcher.TryMatch("/moo/bar", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(0, rd.Count);
+            Assert.True(match);
+            Assert.Empty(values);
         }
 
         [Fact]
@@ -275,13 +303,15 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{p1}/{p2}/");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/moo/bar");
+            var match = matcher.TryMatch("/moo/bar", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal("moo", rd["p1"]);
-            Assert.Equal("bar", rd["p2"]);
+            Assert.True(match);
+            Assert.Equal("moo", values["p1"]);
+            Assert.Equal("bar", values["p2"]);
         }
 
         [Fact]
@@ -290,11 +320,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{p1}/{p2}/baz");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/moo/bar/boo");
+            var match = matcher.TryMatch("/moo/bar/boo", values);
 
             // Assert
-            Assert.Null(rd);
+            Assert.False(match);
         }
 
         [Fact]
@@ -303,11 +335,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{p1}");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/moo/bar");
+            var match = matcher.TryMatch("/moo/bar", values);
 
             // Assert
-            Assert.Null(rd);
+            Assert.False(match);
         }
 
         [Fact]
@@ -316,11 +350,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("DEFAULT.ASPX");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/default.aspx");
+            var match = matcher.TryMatch("/default.aspx", values);
 
             // Assert
-            Assert.NotNull(rd);
+            Assert.True(match);
         }
 
         [Theory]
@@ -336,11 +372,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         {
             var matcher = CreateMatcher(template);
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match(path);
+            var match = matcher.TryMatch(path, values);
 
             // Assert
-            Assert.NotNull(rd);
+            Assert.True(match);
         }
 
         [Fact]
@@ -349,15 +387,17 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{p1}/{p2}", new { p2 = (string)null, foo = "bar" });
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/v1");
+            var match = matcher.TryMatch("/v1", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(3, rd.Count);
-            Assert.Equal("v1", rd["p1"]);
-            Assert.Null(rd["p2"]);
-            Assert.Equal("bar", rd["foo"]);
+            Assert.True(match);
+            Assert.Equal<int>(3, values.Count);
+            Assert.Equal("v1", values["p1"]);
+            Assert.Null(values["p2"]);
+            Assert.Equal("bar", values["foo"]);
         }
 
         [Fact]
@@ -368,17 +408,19 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
                 "date/{y}/{m}/{d}",
                 new { controller = "blog", action = "showpost", m = (string)null, d = (string)null });
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/date/2007/08");
+            var match = matcher.TryMatch("/date/2007/08", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(5, rd.Count);
-            Assert.Equal("blog", rd["controller"]);
-            Assert.Equal("showpost", rd["action"]);
-            Assert.Equal("2007", rd["y"]);
-            Assert.Equal("08", rd["m"]);
-            Assert.Null(rd["d"]);
+            Assert.True(match);
+            Assert.Equal<int>(5, values.Count);
+            Assert.Equal("blog", values["controller"]);
+            Assert.Equal("showpost", values["action"]);
+            Assert.Equal("2007", values["y"]);
+            Assert.Equal("08", values["m"]);
+            Assert.Null(values["d"]);
         }
 
         [Fact]
@@ -502,7 +544,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithMultiSegmentStandardMvcRouteMatches()
+        public void GetRouteDataWithMultiSegmentStandamatchMvcRouteMatches()
         {
             RunTest(
                 "{controller}.mvc/{action}/{id}",
@@ -654,14 +696,16 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/v1/v2/v3");
+            var match = matcher.TryMatch("/v1/v2/v3", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(2, rd.Count);
-            Assert.Equal("v1", rd["p1"]);
-            Assert.Equal("v2/v3", rd["p2"]);
+            Assert.True(match);
+            Assert.Equal<int>(2, values.Count);
+            Assert.Equal("v1", values["p1"]);
+            Assert.Equal("v2/v3", values["p2"]);
         }
 
         [Fact]
@@ -670,14 +714,16 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/v1/");
+            var match = matcher.TryMatch("/v1/", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(2, rd.Count);
-            Assert.Equal("v1", rd["p1"]);
-            Assert.Null(rd["p2"]);
+            Assert.True(match);
+            Assert.Equal<int>(2, values.Count);
+            Assert.Equal("v1", values["p1"]);
+            Assert.Null(values["p2"]);
         }
 
         [Fact]
@@ -686,14 +732,16 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}");
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/v1");
+            var match = matcher.TryMatch("/v1", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(2, rd.Count);
-            Assert.Equal("v1", rd["p1"]);
-            Assert.Null(rd["p2"]);
+            Assert.True(match);
+            Assert.Equal<int>(2, values.Count);
+            Assert.Equal("v1", values["p1"]);
+            Assert.Null(values["p2"]);
         }
 
         [Fact]
@@ -702,14 +750,16 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}", new { p2 = "catchall" });
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/v1");
+            var match = matcher.TryMatch("/v1", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(2, rd.Count);
-            Assert.Equal("v1", rd["p1"]);
-            Assert.Equal("catchall", rd["p2"]);
+            Assert.True(match);
+            Assert.Equal<int>(2, values.Count);
+            Assert.Equal("v1", values["p1"]);
+            Assert.Equal("catchall", values["p2"]);
         }
 
         [Fact]
@@ -718,14 +768,16 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}", new { p2 = "catchall" });
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var rd = matcher.Match("/v1/hello/whatever");
+            var match = matcher.TryMatch("/v1/hello/whatever", values);
 
             // Assert
-            Assert.NotNull(rd);
-            Assert.Equal<int>(2, rd.Count);
-            Assert.Equal("v1", rd["p1"]);
-            Assert.Equal("hello/whatever", rd["p2"]);
+            Assert.True(match);
+            Assert.Equal<int>(2, values.Count);
+            Assert.Equal("v1", values["p1"]);
+            Assert.Equal("hello/whatever", values["p2"]);
         }
 
         [Fact]
@@ -773,17 +825,17 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithWeirdParameterNames()
+        public void GetRouteDataWithWeimatchParameterNames()
         {
             RunTest(
                 "foo/{ }/{.!$%}/{dynamic.data}/{op.tional}",
-                "/foo/space/weird/orderid",
+                "/foo/space/weimatch/omatcherid",
                 new RouteValueDictionary() { { " ", "not a space" }, { "op.tional", "default value" }, { "ran!dom", "va@lue" } },
-                new RouteValueDictionary() { { " ", "space" }, { ".!$%", "weird" }, { "dynamic.data", "orderid" }, { "op.tional", "default value" }, { "ran!dom", "va@lue" } });
+                new RouteValueDictionary() { { " ", "space" }, { ".!$%", "weimatch" }, { "dynamic.data", "omatcherid" }, { "op.tional", "default value" }, { "ran!dom", "va@lue" } });
         }
 
         [Fact]
-        public void GetRouteDataDoesNotMatchRouteWithLiteralSeparatorDefaultsButNoValue()
+        public void GetRouteDataDoesNotMatchRouteWithLiteralSeparatomatchefaultsButNoValue()
         {
             RunTest(
                 "{controller}/{language}-{locale}",
@@ -793,7 +845,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataDoesNotMatchesRouteWithLiteralSeparatorDefaultsAndLeftValue()
+        public void GetRouteDataDoesNotMatchesRouteWithLiteralSeparatomatchefaultsAndLeftValue()
         {
             RunTest(
                 "{controller}/{language}-{locale}",
@@ -803,7 +855,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataDoesNotMatchesRouteWithLiteralSeparatorDefaultsAndRightValue()
+        public void GetRouteDataDoesNotMatchesRouteWithLiteralSeparatomatchefaultsAndRightValue()
         {
             RunTest(
                 "{controller}/{language}-{locale}",
@@ -813,7 +865,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataMatchesRouteWithLiteralSeparatorDefaultsAndValue()
+        public void GetRouteDataMatchesRouteWithLiteralSeparatomatchefaultsAndValue()
         {
             RunTest(
                 "{controller}/{language}-{locale}",
@@ -829,14 +881,16 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var route = CreateMatcher("{controller}/{action?}");
             var url = "/Home/Index";
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var match = route.Match(url);
+            var match = route.TryMatch(url, values);
 
             // Assert
-            Assert.NotNull(match);
-            Assert.Equal(2, match.Values.Count);
-            Assert.Equal("Home", match["controller"]);
-            Assert.Equal("Index", match["action"]);
+            Assert.True(match);
+            Assert.Equal(2, values.Count);
+            Assert.Equal("Home", values["controller"]);
+            Assert.Equal("Index", values["action"]);
         }
 
         [Fact]
@@ -846,14 +900,16 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var route = CreateMatcher("{controller}/{action?}");
             var url = "/Home";
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var match = route.Match(url);
+            var match = route.TryMatch(url, values);
 
             // Assert
-            Assert.NotNull(match);
-            Assert.Equal(1, match.Values.Count);
-            Assert.Equal("Home", match["controller"]);
-            Assert.False(match.ContainsKey("action"));
+            Assert.True(match);
+            Assert.Equal(1, values.Count);
+            Assert.Equal("Home", values["controller"]);
+            Assert.False(values.ContainsKey("action"));
         }
 
         [Fact]
@@ -863,13 +919,15 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var route = CreateMatcher("{controller?}");
             var url = "";
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var match = route.Match(url);
+            var match = route.TryMatch(url, values);
 
             // Assert
-            Assert.NotNull(match);
-            Assert.Equal(0, match.Values.Count);
-            Assert.False(match.ContainsKey("controller"));
+            Assert.True(match);
+            Assert.Equal(0, values.Count);
+            Assert.False(values.ContainsKey("controller"));
         }
 
         [Fact]
@@ -879,12 +937,14 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var route = CreateMatcher("");
             var url = "";
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var match = route.Match(url);
+            var match = route.TryMatch(url, values);
 
             // Assert
-            Assert.NotNull(match);
-            Assert.Equal(0, match.Values.Count);
+            Assert.True(match);
+            Assert.Equal(0, values.Count);
         }
 
         [Fact]
@@ -894,15 +954,17 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var route = CreateMatcher("{controller}/{action?}/{id?}");
             var url = "/Home/Index";
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var match = route.Match(url);
+            var match = route.TryMatch(url, values);
 
             // Assert
-            Assert.NotNull(match);
-            Assert.Equal(2, match.Values.Count);
-            Assert.Equal("Home", match["controller"]);
-            Assert.Equal("Index", match["action"]);
-            Assert.False(match.ContainsKey("id"));
+            Assert.True(match);
+            Assert.Equal(2, values.Count);
+            Assert.Equal("Home", values["controller"]);
+            Assert.Equal("Index", values["action"]);
+            Assert.False(values.ContainsKey("id"));
         }
 
         private TemplateMatcher CreateMatcher(string template, object defaults = null)
@@ -923,21 +985,23 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
                 TemplateParser.Parse(template), 
                 defaults ?? new RouteValueDictionary());
 
+            var values = new RouteValueDictionary();
+
             // Act
-            var match = matcher.Match(new PathString(path));
+            var match = matcher.TryMatch(new PathString(path), values);
 
             // Assert
             if (expected == null)
             {
-                Assert.Null(match);
+                Assert.False(match);
             }
             else
             {
-                Assert.NotNull(match);
-                Assert.Equal(expected.Count, match.Values.Count);
-                foreach (string key in match.Keys)
+                Assert.True(match);
+                Assert.Equal(expected.Count, values.Count);
+                foreach (string key in values.Keys)
                 {
-                    Assert.Equal(expected[key], match[key]);
+                    Assert.Equal(expected[key], values[key]);
                 }
             }
         }

--- a/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateMatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateMatcherTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         private static IInlineConstraintResolver _inlineConstraintResolver = GetInlineConstraintResolver();
 
         [Fact]
-        public void MatchSingleRoute()
+        public void TryMatch_Success()
         {
             // Arrange
             var matcher = CreateMatcher("{controller}/{action}/{id}");
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void NoMatchSingleRoute()
+        public void TryMatch_Fails()
         {
             // Arrange
             var matcher = CreateMatcher("{controller}/{action}/{id}");
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchSingleRouteWithDefaults()
+        public void TryMatch_WithDefaults_Success()
         {
             // Arrange
             var matcher = CreateMatcher("{controller}/{action}/{id}", new { id = "default id" });
@@ -58,13 +58,14 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var match = matcher.TryMatch("/Bank/DoAction", values);
 
             // Assert
+            Assert.True(match);
             Assert.Equal("Bank", values["controller"]);
             Assert.Equal("DoAction", values["action"]);
             Assert.Equal("default id", values["id"]);
         }
 
         [Fact]
-        public void NoMatchSingleRouteWithDefaults()
+        public void TryMatch_WithDefaults_Fails()
         {
             // Arrange
             var matcher = CreateMatcher("{controller}/{action}/{id}", new { id = "default id" });
@@ -79,7 +80,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchRouteWithLiterals()
+        public void TryMatch_WithLiterals_Success()
         {
             // Arrange
             var matcher = CreateMatcher("moo/{p1}/bar/{p2}", new { p2 = "default p2" });
@@ -90,12 +91,13 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var match = matcher.TryMatch("/moo/111/bar/222", values);
 
             // Assert
+            Assert.True(match);
             Assert.Equal("111", values["p1"]);
             Assert.Equal("222", values["p2"]);
         }
 
         [Fact]
-        public void MatchRouteWithLiteralsAndDefaults()
+        public void TryMatch_RouteWithLiteralsAndDefaults_Success()
         {
             // Arrange
             var matcher = CreateMatcher("moo/{p1}/bar/{p2}", new { p2 = "default p2" });
@@ -106,6 +108,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var match = matcher.TryMatch("/moo/111/bar/", values);
 
             // Assert
+            Assert.True(match);
             Assert.Equal("111", values["p1"]);
             Assert.Equal("default p2", values["p2"]);
         }
@@ -115,7 +118,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         [InlineData(@"{p1:regex(^\w+\@\w+\.\w+)}", "/asd@assds.com")] // email
         [InlineData(@"{p1:regex(([}}])\w+)}", "/}sda")] // Not balanced }
         [InlineData(@"{p1:regex(([{{)])\w+)}", "/})sda")] // Not balanced {
-        public void MatchRoute_RegularExpression_Valid(
+        public void TryMatch_RegularExpressionConstraint_Valid(
             string template,
             string path)
         {
@@ -145,7 +148,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         [InlineData("moo/.{p2?}", "/moo", null, null)]
         [InlineData("moo/{p1}.{p2?}", "/moo/....", "..", ".")]
         [InlineData("moo/{p1}.{p2?}", "/moo/.bar", ".bar", null)]
-        public void MatchRoute_OptionalParameter_FollowedByPeriod_Valid(
+        public void TryMatch_OptionalParameter_FollowedByPeriod_Valid(
             string template,
             string path,
             string p1,
@@ -160,6 +163,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var match = matcher.TryMatch(path, values);
 
             // Assert
+            Assert.True(match);
             if (p1 != null)
             {
                 Assert.Equal(p1, values["p1"]);
@@ -178,7 +182,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         [InlineData("{p1}.{p2?}/{p3}", "/foo/bar", "foo", null, "bar")]
         [InlineData("{p1}.{p2?}/{p3}", "/.foo/bar", ".foo", null, "bar")]
         [InlineData("{p1}/{p2}/{p3?}", "/foo/bar/baz", "foo", "bar", "baz")]
-        public void MatchRoute_OptionalParameter_FollowedByPeriod_3Parameters_Valid(
+        public void TryMatch_OptionalParameter_FollowedByPeriod_3Parameters_Valid(
             string template,
             string path,
             string p1,
@@ -194,6 +198,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var match = matcher.TryMatch(path, values);
 
             // Assert
+            Assert.True(match);
             Assert.Equal(p1, values["p1"]);
 
             if (p2 != null)
@@ -220,7 +225,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         [InlineData("{p1}.{p2?}/{p3}", "/foo./bar")]
         [InlineData("moo/.{p2?}", "/moo/.")]
         [InlineData("{p1}.{p2}/{p3}", "/.foo/bar")]
-        public void MatchRoute_OptionalParameter_FollowedByPeriod_Invalid(string template, string path)
+        public void TryMatch_OptionalParameter_FollowedByPeriod_Invalid(string template, string path)
         {
             // Arrange
             var matcher = CreateMatcher(template);
@@ -235,7 +240,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchRouteWithOnlyLiterals()
+        public void TryMatch_RouteWithOnlyLiterals_Success()
         {
             // Arrange
             var matcher = CreateMatcher("moo/bar");
@@ -251,7 +256,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void NoMatchRouteWithOnlyLiterals()
+        public void TryMatch_RouteWithOnlyLiterals_Fails()
         {
             // Arrange
             var matcher = CreateMatcher("moo/bars");
@@ -266,7 +271,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchRouteWithExtraSeparators()
+        public void TryMatch_RouteWithExtraSeparators_Success()
         {
             // Arrange
             var matcher = CreateMatcher("moo/bar");
@@ -282,7 +287,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchRouteUrlWithExtraSeparators()
+        public void TryMatch_UrlWithExtraSeparators_Success()
         {
             // Arrange
             var matcher = CreateMatcher("moo/bar/");
@@ -298,7 +303,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchRouteUrlWithParametersAndExtraSeparators()
+        public void TryMatch_RouteWithParametersAndExtraSeparators_Success()
         {
             // Arrange
             var matcher = CreateMatcher("{p1}/{p2}/");
@@ -315,7 +320,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void NoMatchRouteUrlWithDifferentLiterals()
+        public void TryMatch_RouteWithDifferentLiterals_Fails()
         {
             // Arrange
             var matcher = CreateMatcher("{p1}/{p2}/baz");
@@ -330,7 +335,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void NoMatchLongerUrl()
+        public void TryMatch_LongerUrl_Fails()
         {
             // Arrange
             var matcher = CreateMatcher("{p1}");
@@ -345,7 +350,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchSimpleFilename()
+        public void TryMatch_SimpleFilename_Success()
         {
             // Arrange
             var matcher = CreateMatcher("DEFAULT.ASPX");
@@ -368,7 +373,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         [InlineData("{prefix}xyz{suffix}", "/xyzxyzxyz")]
         [InlineData("{prefix}aa{suffix}", "/aaaaa")]
         [InlineData("{prefix}aaa{suffix}", "/aaaaa")]
-        public void VerifyRouteMatchesWithContext(string template, string path)
+        public void TryMatch_RouteWithComplexSegment_Success(string template, string path)
         {
             var matcher = CreateMatcher(template);
 
@@ -382,7 +387,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchRouteWithExtraDefaultValues()
+        public void TryMatch_RouteWithExtraDefaultValues_Success()
         {
             // Arrange
             var matcher = CreateMatcher("{p1}/{p2}", new { p2 = (string)null, foo = "bar" });
@@ -401,7 +406,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchPrettyRouteWithExtraDefaultValues()
+        public void TryMatch_PrettyRouteWithExtraDefaultValues_Success()
         {
             // Arrange
             var matcher = CreateMatcher(
@@ -424,7 +429,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithMultiSegmentParamsOnBothEndsMatches()
+        public void TryMatch_WithMultiSegmentParamsOnBothEndsMatches()
         {
             RunTest(
                 "language/{lang}-{region}",
@@ -434,7 +439,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithMultiSegmentParamsOnLeftEndMatches()
+        public void TryMatch_WithMultiSegmentParamsOnLeftEndMatches()
         {
             RunTest(
                 "language/{lang}-{region}a",
@@ -444,7 +449,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithMultiSegmentParamsOnRightEndMatches()
+        public void TryMatch_WithMultiSegmentParamsOnRightEndMatches()
         {
             RunTest(
                 "language/a{lang}-{region}",
@@ -454,7 +459,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithMultiSegmentParamsOnNeitherEndMatches()
+        public void TryMatch_WithMultiSegmentParamsOnNeitherEndMatches()
         {
             RunTest(
                 "language/a{lang}-{region}a",
@@ -464,7 +469,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithMultiSegmentParamsOnNeitherEndDoesNotMatch()
+        public void TryMatch_WithMultiSegmentParamsOnNeitherEndDoesNotMatch()
         {
             RunTest(
                 "language/a{lang}-{region}a",
@@ -474,7 +479,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithMultiSegmentParamsOnNeitherEndDoesNotMatch2()
+        public void TryMatch_WithMultiSegmentParamsOnNeitherEndDoesNotMatch2()
         {
             RunTest(
                 "language/a{lang}-{region}a",
@@ -484,7 +489,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithSimpleMultiSegmentParamsOnBothEndsMatches()
+        public void TryMatch_WithSimpleMultiSegmentParamsOnBothEndsMatches()
         {
             RunTest(
                 "language/{lang}",
@@ -494,7 +499,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithSimpleMultiSegmentParamsOnBothEndsTrailingSlashDoesNotMatch()
+        public void TryMatch_WithSimpleMultiSegmentParamsOnBothEndsTrailingSlashDoesNotMatch()
         {
             RunTest(
                 "language/{lang}",
@@ -504,7 +509,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithSimpleMultiSegmentParamsOnBothEndsDoesNotMatch()
+        public void TryMatch_WithSimpleMultiSegmentParamsOnBothEndsDoesNotMatch()
         {
             RunTest(
                 "language/{lang}",
@@ -514,7 +519,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithSimpleMultiSegmentParamsOnLeftEndMatches()
+        public void TryMatch_WithSimpleMultiSegmentParamsOnLeftEndMatches()
         {
             RunTest(
                 "language/{lang}-",
@@ -524,7 +529,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithSimpleMultiSegmentParamsOnRightEndMatches()
+        public void TryMatch_WithSimpleMultiSegmentParamsOnRightEndMatches()
         {
             RunTest(
                 "language/a{lang}",
@@ -534,7 +539,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithSimpleMultiSegmentParamsOnNeitherEndMatches()
+        public void TryMatch_WithSimpleMultiSegmentParamsOnNeitherEndMatches()
         {
             RunTest(
                 "language/a{lang}a",
@@ -544,7 +549,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithMultiSegmentStandamatchMvcRouteMatches()
+        public void TryMatch_WithMultiSegmentStandamatchMvcRouteMatches()
         {
             RunTest(
                 "{controller}.mvc/{action}/{id}",
@@ -554,7 +559,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithMultiSegmentParamsOnBothEndsWithDefaultValuesMatches()
+        public void TryMatch_WithMultiSegmentParamsOnBothEndsWithDefaultValuesMatches()
         {
             RunTest(
                 "language/{lang}-{region}",
@@ -564,7 +569,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithMultiSegmentWithRepeatedDots()
+        public void TryMatch_WithUrlWithMultiSegmentWithRepeatedDots()
         {
             RunTest(
                 "{Controller}..mvc/{id}/{Param1}",
@@ -574,7 +579,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithTwoRepeatedDots()
+        public void TryMatch_WithUrlWithTwoRepeatedDots()
         {
             RunTest(
                 "{Controller}.mvc/../{action}",
@@ -584,7 +589,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithThreeRepeatedDots()
+        public void TryMatch_WithUrlWithThreeRepeatedDots()
         {
             RunTest(
                 "{Controller}.mvc/.../{action}",
@@ -594,7 +599,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithManyRepeatedDots()
+        public void TryMatch_WithUrlWithManyRepeatedDots()
         {
             RunTest(
                 "{Controller}.mvc/../../../{action}",
@@ -604,7 +609,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithExclamationPoint()
+        public void TryMatch_WithUrlWithExclamationPoint()
         {
             RunTest(
                 "{Controller}.mvc!/{action}",
@@ -614,7 +619,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithStartingDotDotSlash()
+        public void TryMatch_WithUrlWithStartingDotDotSlash()
         {
             RunTest(
                 "../{Controller}.mvc",
@@ -624,7 +629,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithStartingBackslash()
+        public void TryMatch_WithUrlWithStartingBackslash()
         {
             RunTest(
                 @"\{Controller}.mvc",
@@ -634,7 +639,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithBackslashSeparators()
+        public void TryMatch_WithUrlWithBackslashSeparators()
         {
             RunTest(
                 @"{Controller}.mvc\{id}\{Param1}",
@@ -644,7 +649,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithParenthesesLiterals()
+        public void TryMatch_WithUrlWithParenthesesLiterals()
         {
             RunTest(
                 @"(Controller).mvc",
@@ -654,7 +659,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithTrailingSlashSpace()
+        public void TryMatch_WithUrlWithTrailingSlashSpace()
         {
             RunTest(
                 @"Controller.mvc/ ",
@@ -664,7 +669,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithUrlWithTrailingSpace()
+        public void TryMatch_WithUrlWithTrailingSpace()
         {
             RunTest(
                 @"Controller.mvc ",
@@ -674,7 +679,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithCatchAllCapturesDots()
+        public void TryMatch_WithCatchAllCapturesDots()
         {
             // DevDiv Bugs 189892: UrlRouting: Catch all parameter cannot capture url segments that contain the "."
             RunTest(
@@ -691,7 +696,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void RouteWithCatchAllClauseCapturesManySlashes()
+        public void TryMatch_RouteWithCatchAllClauseCapturesManySlashes()
         {
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}");
@@ -709,7 +714,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void RouteWithCatchAllClauseCapturesTrailingSlash()
+        public void TryMatch_RouteWithCatchAllClauseCapturesTrailingSlash()
         {
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}");
@@ -727,7 +732,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void RouteWithCatchAllClauseCapturesEmptyContent()
+        public void TryMatch_RouteWithCatchAllClauseCapturesEmptyContent()
         {
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}");
@@ -745,7 +750,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void RouteWithCatchAllClauseUsesDefaultValueForEmptyContent()
+        public void TryMatch_RouteWithCatchAllClauseUsesDefaultValueForEmptyContent()
         {
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}", new { p2 = "catchall" });
@@ -763,7 +768,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void RouteWithCatchAllClauseIgnoresDefaultValueForNonEmptyContent()
+        public void TryMatch_RouteWithCatchAllClauseIgnoresDefaultValueForNonEmptyContent()
         {
             // Arrange
             var matcher = CreateMatcher("{p1}/{*p2}", new { p2 = "catchall" });
@@ -781,7 +786,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataDoesNotMatchOnlyLeftLiteralMatch()
+        public void TryMatch_DoesNotMatchOnlyLeftLiteralMatch()
         {
             // DevDiv Bugs 191180: UrlRouting: Wrong template getting matched if a url segment is a substring of the requested url
             RunTest(
@@ -792,7 +797,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataDoesNotMatchOnlyRightLiteralMatch()
+        public void TryMatch_DoesNotMatchOnlyRightLiteralMatch()
         {
             // DevDiv Bugs 191180: UrlRouting: Wrong template getting matched if a url segment is a substring of the requested url
             RunTest(
@@ -803,7 +808,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataDoesNotMatchMiddleLiteralMatch()
+        public void TryMatch_DoesNotMatchMiddleLiteralMatch()
         {
             // DevDiv Bugs 191180: UrlRouting: Wrong template getting matched if a url segment is a substring of the requested url
             RunTest(
@@ -814,7 +819,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataDoesMatchesExactLiteralMatch()
+        public void TryMatch_DoesMatchesExactLiteralMatch()
         {
             // DevDiv Bugs 191180: UrlRouting: Wrong template getting matched if a url segment is a substring of the requested url
             RunTest(
@@ -825,7 +830,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataWithWeimatchParameterNames()
+        public void TryMatch_WithWeimatchParameterNames()
         {
             RunTest(
                 "foo/{ }/{.!$%}/{dynamic.data}/{op.tional}",
@@ -835,7 +840,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataDoesNotMatchRouteWithLiteralSeparatomatchefaultsButNoValue()
+        public void TryMatch_DoesNotMatchRouteWithLiteralSeparatomatchefaultsButNoValue()
         {
             RunTest(
                 "{controller}/{language}-{locale}",
@@ -845,7 +850,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataDoesNotMatchesRouteWithLiteralSeparatomatchefaultsAndLeftValue()
+        public void TryMatch_DoesNotMatchesRouteWithLiteralSeparatomatchefaultsAndLeftValue()
         {
             RunTest(
                 "{controller}/{language}-{locale}",
@@ -855,7 +860,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataDoesNotMatchesRouteWithLiteralSeparatomatchefaultsAndRightValue()
+        public void TryMatch_DoesNotMatchesRouteWithLiteralSeparatomatchefaultsAndRightValue()
         {
             RunTest(
                 "{controller}/{language}-{locale}",
@@ -865,7 +870,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void GetRouteDataMatchesRouteWithLiteralSeparatomatchefaultsAndValue()
+        public void TryMatch_MatchesRouteWithLiteralSeparatomatchefaultsAndValue()
         {
             RunTest(
                 "{controller}/{language}-{locale}",
@@ -875,7 +880,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchSetsOptionalParameter()
+        public void TryMatch_SetsOptionalParameter()
         {
             // Arrange
             var route = CreateMatcher("{controller}/{action?}");
@@ -894,7 +899,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchDoesNotSetOptionalParameter()
+        public void TryMatch_DoesNotSetOptionalParameter()
         {
             // Arrange
             var route = CreateMatcher("{controller}/{action?}");
@@ -913,7 +918,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchDoesNotSetOptionalParameter_EmptyString()
+        public void TryMatch_DoesNotSetOptionalParameter_EmptyString()
         {
             // Arrange
             var route = CreateMatcher("{controller?}");
@@ -931,7 +936,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void Match_EmptyRouteWith_EmptyString()
+        public void TryMatch__EmptyRouteWith_EmptyString()
         {
             // Arrange
             var route = CreateMatcher("");
@@ -948,7 +953,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         }
 
         [Fact]
-        public void MatchMultipleOptionalParameters()
+        public void TryMatch_MultipleOptionalParameters()
         {
             // Arrange
             var route = CreateMatcher("{controller}/{action?}/{id?}");

--- a/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouterTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouterTest.cs
@@ -1533,7 +1533,6 @@ namespace Microsoft.AspNetCore.Routing.Tree
             // Assert
             Assert.NotEqual(nestedValues, context.RouteData.Values);
 
-            // The new routedata is a copy
             Assert.Equal("Index", context.RouteData.Values["action"]);
             Assert.Equal("Index", nestedValues["action"]);
             Assert.DoesNotContain(context.RouteData.Values, kvp => kvp.Key == "test_route_group");


### PR DESCRIPTION
This changes TemplateMatcher to mutate RouteData.Values directly instead
of creating a new dictionary and then merging in values. This is one the
biggest single costs in routing in terms of both allocations and execution
time.

So Match now becomes TryMatch. This will dirty the state of the RVD, so
the caller needs to snapshot it before calling into it (handled
inside the TreeRouter or RouteCollection).

Some subtle changes were needed to how/when values are added to be
compatible with the existing tests. The general idea is that we add null
values for non-parameter defaults or catchalls, but only if they don't
trounce an existing value. This logic used to live in MergeValues but now
it's in TryMatch since TryMatch might be working from existing data.

Also fixed the .sln to avoid building a package that we use as shared
source.