### PR TITLE
[Perf] Refactor TemplateBinder.GetValues to avoid an expensive copy of RouteValueDictionary

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
@@ -235,10 +235,6 @@ namespace Microsoft.AspNetCore.Routing.Template
                         // If it's a parameter, get its value
                         object value;
                         var hasValue = acceptedValues.TryGetValue(part.Name, out value);
-                        if (hasValue)
-                        {
-                            acceptedValues.Remove(part.Name);
-                        }
 
                         var isSameAsDefault = false;
                         object defaultValue;
@@ -292,6 +288,12 @@ namespace Microsoft.AspNetCore.Routing.Template
             var wroteFirst = false;
             foreach (var kvp in acceptedValues)
             {
+                if (_template.GetParameter(kvp.Key) != null)
+                {
+                    // We already added the template parameters.
+                    continue;
+                }
+
                 if (_defaults != null && _defaults.ContainsKey(kvp.Key))
                 {
                     // This value is a 'filter' we don't need to put it in the query string.
@@ -494,7 +496,7 @@ namespace Microsoft.AspNetCore.Routing.Template
 
             private string DebuggerToString()
             {
-                return string.Format("{{Accepted: '{0}'}}", string.Join(", ", _acceptedValues.Keys));
+                return string.Format("{{Accepted: '{0}'}}", string.Join(", ", AcceptedValues.Keys));
             }
         }
     }

--- a/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
@@ -347,21 +347,21 @@ namespace Microsoft.AspNetCore.Routing.Template
             if (values != null)
             {
                 object value;
-                if (values.TryGetValue(name, out value))
+                if (values.TryGetValue(name, out value) && 
+                    IsRoutePartNonEmpty(value))
                 {
-                    if (IsRoutePartNonEmpty(value))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
 
-            if (ambientValues != null && ambientValues.ContainsKey(name))
+            if (ambientValues != null 
+                && ambientValues.ContainsKey(name))
             {
                 return true;
             }
 
-            if (_defaults != null && _defaults.ContainsKey(name))
+            if (_defaults != null 
+                && _defaults.ContainsKey(name))
             {
                 return true;
             }

--- a/test/Microsoft.AspNetCore.Routing.Tests/RouteTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/RouteTest.cs
@@ -975,7 +975,9 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Same(route, pathData.Router);
             Assert.Empty(pathData.DataTokens);
 
-            Assert.Equal(expectedValues, constraint.Values);
+            Assert.Equal(
+                expectedValues.OrderBy(kvp => kvp.Key), 
+                constraint.Values.OrderBy(kvp => kvp.Key));
         }
 
         // Non-parameter default values from the routing generating a link are not in the 'values'
@@ -1006,7 +1008,9 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Same(route, pathData.Router);
             Assert.Empty(pathData.DataTokens);
 
-            Assert.Equal(expectedValues, constraint.Values);
+            Assert.Equal(
+                expectedValues.OrderBy(kvp => kvp.Key), 
+                constraint.Values.OrderBy(kvp => kvp.Key));
         }
 
         // Default values are visible to the constraint when they are used to fill a parameter.


### PR DESCRIPTION
Reference Issue https://github.com/aspnet/Mvc/issues/4593 

loadtest with 3000 requests for the home page of the MusicStore app

Before
-------
![image](https://cloud.githubusercontent.com/assets/8011073/15259735/e22592da-1907-11e6-9103-f68953b851bb.png)

After
------

![image](https://cloud.githubusercontent.com/assets/8011073/15259750/f566aee2-1907-11e6-8b57-3188fdb81348.png)


4.8% saving in the total bytes allocated.