### PR TITLE
! RegexRouteConstraint only did a partial match

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Constraints/PartialRegexInlineRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/PartialRegexInlineRouteConstraint.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Routing.Constraints
+{
+    /// <summary>
+    /// Represents a partial match regex constraint which can be used as an inlineConstraint.
+    /// </summary>
+    public class PartialRegexInlineRouteConstraint : RegexRouteConstraint
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegexInlineRouteConstraint" /> class.
+        /// </summary>
+        /// <param name="regexPattern">The regular expression pattern to match.</param>
+        public PartialRegexInlineRouteConstraint(string regexPattern)
+            : base(regexPattern)
+        {
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/Constraints/RegexInlineRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/RegexInlineRouteConstraint.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints
         /// </summary>
         /// <param name="regexPattern">The regular expression pattern to match.</param>
         public RegexInlineRouteConstraint(string regexPattern)
-            : base(regexPattern)
+            : base("^" + regexPattern + "$")
         {
         }
     }

--- a/src/Microsoft.AspNetCore.Routing/Constraints/RegexRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/RegexRouteConstraint.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints
                 throw new ArgumentNullException(nameof(regex));
             }
 
-            Constraint = regex;
+            Constraint = "^" + regex + "$";
         }
 
         public RegexRouteConstraint(string regexPattern)
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             }
 
             Constraint = new Regex(
-                regexPattern,
+                "^" + regexPattern + "$",
                 RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
                 RegexMatchTimeout);
         }

--- a/src/Microsoft.AspNetCore.Routing/Constraints/RegexRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/RegexRouteConstraint.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints
                 throw new ArgumentNullException(nameof(regex));
             }
 
-            Constraint = "^" + regex + "$";
+            Constraint = regex;
         }
 
         public RegexRouteConstraint(string regexPattern)
@@ -30,7 +30,7 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             }
 
             Constraint = new Regex(
-                "^" + regexPattern + "$",
+                regexPattern,
                 RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
                 RegexMatchTimeout);
         }

--- a/src/Microsoft.AspNetCore.Routing/RouteOptions.cs
+++ b/src/Microsoft.AspNetCore.Routing/RouteOptions.cs
@@ -65,6 +65,7 @@ namespace Microsoft.AspNetCore.Routing
                 // Regex-based constraints
                 { "alpha", typeof(AlphaRouteConstraint) },
                 { "regex", typeof(RegexInlineRouteConstraint) },
+                { "partialregex", typeof(PartialRegexInlineRouteConstraint) },
 
                 {"required", typeof(RequiredRouteConstraint) },
             };

--- a/test/Microsoft.AspNetCore.Routing.Tests/Constraints/PartialRegexInlineRouteConstraintTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Constraints/PartialRegexInlineRouteConstraintTests.cs
@@ -1,6 +1,3 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.Testing;
@@ -9,25 +6,22 @@ using Xunit;
 
 namespace Microsoft.AspNetCore.Routing.Tests
 {
-    public class RegexInlineRouteConstraintTests
+    public class PartialRegexInlineRouteConstraintTests
     {
         [Theory]
         [InlineData("abc", "abc", true)]    // simple match
         [InlineData("Abc", "abc", true)]    // case insensitive match
-        [InlineData("Abc ", "abc", false)]   // Extra space on input match (because we don't add ^({0})$
-        [InlineData("Abcd", "abc", false)]   // Extra char
-        [InlineData("^Abcd", "abc", false)]  // Extra special char
+        [InlineData("Abc ", "abc", true)]   // Extra space on input match (because we don't add ^({0})$
+        [InlineData("Abcd", "abc", true)]   // Extra char
+        [InlineData("^Abcd", "abc", true)]  // Extra special char
         [InlineData("Abc", " abc", false)]  // Missing char
-        [InlineData("123-456-2334", @"\d{3}-\d{3}-\d{4}", true)] // ssn
-        [InlineData(@"12/4/2013", @"\d{1,2}\/\d{1,2}\/\d{4}", true)] // date
-        [InlineData(@"abc@def.com", @"\w+[\w\.]*\@\w+((-\w+)|(\w*))\.[a-z]{2,3}", true)] // email
         public void RegexInlineConstraintBuildRegexVerbatimFromInput(
             string routeValue,
             string constraintValue,
             bool shouldMatch)
         {
             // Arrange
-            var constraint = new RegexInlineRouteConstraint(constraintValue);
+            var constraint = new PartialRegexInlineRouteConstraint(constraintValue);
             var values = new RouteValueDictionary(new { controller = routeValue });
 
             // Act
@@ -46,7 +40,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
         public void RegexInlineConstraint_FailsIfKeyIsNotFoundInRouteValues()
         {
             // Arrange
-            var constraint = new RegexInlineRouteConstraint("abc");
+            var constraint = new PartialRegexInlineRouteConstraint("^abc$");
             var values = new RouteValueDictionary(new { action = "abc" });
 
             // Act
@@ -74,7 +68,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
             }
 
             // Arrange
-            var constraint = new RegexInlineRouteConstraint("([a-z]+)");
+            var constraint = new PartialRegexInlineRouteConstraint("^([a-z]+)$");
             var values = new RouteValueDictionary(new { controller = "\u0130" }); // Turkish upper-case dotted I
 
             using (new CultureReplacer(culture))


### PR DESCRIPTION
Seems like the RegexRouteConstraint only did a partial match on route values (which is not what the docs suggested)

e.g. Having a route with a parameter like `{ssn:regex(d{3}-d{2}-d{4})}` would match `123-45-6789`, but would also match `alpha123-45-6789`

The proposed change enforces start and end of string characters in the pattern.


If a regular expression constraint with a partial match is required, I'd suggest adding a separate constraint for that (`PartialRegexRouteConstraint` with an inline constraint name of `partialregex`?)