### PR TITLE
Add DoesNotContainConstraint to Routing Constraings

### DIFF
--- a/src/Microsoft.AspNet.Routing/Constraints/DoesNotContainConstraint.cs
+++ b/src/Microsoft.AspNet.Routing/Constraints/DoesNotContainConstraint.cs
@@ -1,0 +1,44 @@
+public class DoesNotContainConstraint : IRouteConstraint
+    {
+        private readonly string m_Substring;
+
+        public DoesNotContainConstraint(string substring)
+        {
+            m_Substring = substring;
+        }
+
+        public bool Match(HttpContext httpContext, IRouter route, string routeKey, IDictionary<string, object> values, RouteDirection routeDirection)
+        {
+            if (httpContext == null)
+            {
+                throw new ArgumentNullException(nameof(httpContext));
+            }
+
+            if (route == null)
+            {
+                throw new ArgumentNullException(nameof(route));
+            }
+
+            if (routeKey == null)
+            {
+                throw new ArgumentNullException(nameof(routeKey));
+            }
+
+            if (values == null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
+            object routeValue;
+
+            if (values.TryGetValue(routeKey, out routeValue)
+                && routeValue != null)
+            {
+                string parameterValueString = Convert.ToString(routeValue, CultureInfo.InvariantCulture);
+
+                return !parameterValueString.Contains(m_Substring);
+            }
+
+            return true;
+        }
+    }

--- a/src/Microsoft.AspNet.Routing/Constraints/DoesNotContainConstraint.cs
+++ b/src/Microsoft.AspNet.Routing/Constraints/DoesNotContainConstraint.cs
@@ -1,13 +1,30 @@
-public class DoesNotContainConstraint : IRouteConstraint
-    {
-        private readonly string m_Substring;
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-        public DoesNotContainConstraint(string substring)
+using System;
+using System.Linq;
+using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNet.Routing.Constraints
+{
+    /// <summary>
+    /// Constrains a route parameter to not contain any of the input strings.
+    /// </summary>
+    public class DoesNotContainConstraint : IRouteConstraint
+    {
+        private readonly string[] m_ExcludedStrings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DoesNotContainConstraint" /> class.
+        /// </summary>
+        public DoesNotContainConstraint(params string[] excludedStrings)
         {
-            m_Substring = substring;
+            m_ExcludedStrings = excludedStrings;
         }
 
-        public bool Match(HttpContext httpContext, IRouter route, string routeKey, IDictionary<string, object> values, RouteDirection routeDirection)
+        public bool Match(HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection)
         {
             if (httpContext == null)
             {
@@ -31,14 +48,14 @@ public class DoesNotContainConstraint : IRouteConstraint
 
             object routeValue;
 
-            if (values.TryGetValue(routeKey, out routeValue)
-                && routeValue != null)
+            if (values.TryGetValue(routeKey, out routeValue) && routeValue != null)
             {
                 string parameterValueString = Convert.ToString(routeValue, CultureInfo.InvariantCulture);
 
-                return !parameterValueString.Contains(m_Substring);
+                return m_ExcludedStrings.All(s => !parameterValueString.Contains(s));
             }
 
             return true;
         }
     }
+}


### PR DESCRIPTION
This constraint is very useful for the modern SPA applications.  For example if we want a SPA page for all request apart from static files and "/api" route we can use the following snippet:

```
app.UseMvc(routes =>
{
    routes.MapRoute(
        name: "api",
        template: "api/{controller}/{action}");

    routes.MapRoute(
        name: "angular",
        template: "{*url}",
        defaults: new {controller = "Home", action = "Index"},
        constraints: new {url = new DoesNotContainConstraint(".", "api/") });                
});
```

If we don't have such a constraint it will result in all requests to non-existing files (like e.g. .map.js files that Chrome does, etc...) and to non-existing api calls (mistype, etc...) result in the home page of the application returned which is not quite ideal situation. RegexConstraint can possibly be used, but it's too complex and most likely slower for such a simple and commonly required case.
