### PR TITLE
[Fixes #370] Raw route values should be restored after template binder failing binding values when generating a url

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
@@ -171,8 +171,7 @@ namespace Microsoft.AspNetCore.Routing.Template
 
             // Add any ambient values that don't match parameters - they need to be visible to constraints
             // but they will ignored by link generation.
-            // Perf: Lazily allocate RouteValueDictionary only when needed as in most cases combined is same as accepted values
-            RouteValueDictionary combinedValues = null;
+            var combinedValues = new RouteValueDictionary(context.AcceptedValues);
             if (ambientValues != null)
             {
                 foreach (var kvp in ambientValues)
@@ -182,10 +181,6 @@ namespace Microsoft.AspNetCore.Routing.Template
                         var parameter = GetParameter(kvp.Key);
                         if (parameter == null && !context.AcceptedValues.ContainsKey(kvp.Key))
                         {
-                            if (combinedValues == null)
-                            {
-                                combinedValues = new RouteValueDictionary(context.AcceptedValues);
-                            }
                             combinedValues.Add(kvp.Key, kvp.Value);
                         }
                     }
@@ -195,7 +190,7 @@ namespace Microsoft.AspNetCore.Routing.Template
             return new TemplateValuesResult()
             {
                 AcceptedValues = context.AcceptedValues,
-                CombinedValues = combinedValues ?? context.AcceptedValues
+                CombinedValues = combinedValues,
             };
         }
 

--- a/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
@@ -691,6 +691,34 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
                 "/UrlEncode[[v1]]");
         }
 
+        [Fact]
+        public void TemplateBinder_KeepsExplicitlySuppliedRouteValues_OnFailedRouetMatch()
+        {
+            // Arrange
+            var template = "{area?}/{controller=Home}/{action=Index}/{id?}";
+            var encoder = new UrlTestEncoder();
+            var binder = new TemplateBinder(
+                new UrlTestEncoder(),
+                new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy(encoder)),
+                TemplateParser.Parse(template),
+                defaults: null);
+            var ambientValues = new RouteValueDictionary();
+            var routeValues = new RouteValueDictionary(new { controller = "Test", action = "Index" });
+
+            // Act
+            var templateValuesResult = binder.GetValues(ambientValues, routeValues);
+            var boundTemplate = binder.BindValues(templateValuesResult.AcceptedValues);
+
+            // Assert
+            Assert.Null(boundTemplate);
+            Assert.Equal(2, templateValuesResult.CombinedValues.Count);
+            object routeValue;
+            Assert.True(templateValuesResult.CombinedValues.TryGetValue("controller", out routeValue));
+            Assert.Equal("Test", routeValue?.ToString());
+            Assert.True(templateValuesResult.CombinedValues.TryGetValue("action", out routeValue));
+            Assert.Equal("Index", routeValue?.ToString());
+        }
+
 #if ROUTE_COLLECTION
 
                 [Fact]


### PR DESCRIPTION
@rynowak 