### PR TITLE
Make TreeRouter restore RouteData snapshots consistently. Fixes #394.

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
+++ b/src/Microsoft.AspNetCore.Routing/Tree/TreeRouter.cs
@@ -192,13 +192,14 @@ namespace Microsoft.AspNetCore.Routing.Tree
                     {
                         var entry = item.Entry;
                         var matcher = item.TemplateMatcher;
-                        if (!matcher.TryMatch(context.HttpContext.Request.Path, context.RouteData.Values))
-                        {
-                            continue;
-                        }
 
                         try
                         {
+                            if (!matcher.TryMatch(context.HttpContext.Request.Path, context.RouteData.Values))
+                            {
+                                continue;
+                            }
+
                             if (!RouteConstraintMatcher.Match(
                                 entry.Constraints,
                                 context.RouteData.Values,

--- a/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouterTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouterTest.cs
@@ -1844,6 +1844,43 @@ namespace Microsoft.AspNetCore.Routing.Tree
             Assert.Equal(next.Object.GetType(), nestedRouters[0].GetType());
         }
 
+        [Fact]
+        public async Task TreeRouter_SnapshotsRouteData_ResetsBeforeMatchingEachRouteEntry()
+        {
+            // This test replicates a scenario raised as issue https://github.com/aspnet/Routing/issues/394
+            // The RouteValueDictionary entries populated while matching route entries should not be left
+            // in place if the route entry turns out not to match, because that would leak unwanted state
+            // to subsequent route entries and might cause "An element with the key ... already exists"
+            // exceptions.
+
+            // Arrange
+            RouteValueDictionary nestedValues = null;
+            var next = new Mock<IRouter>();
+            next
+                .Setup(r => r.RouteAsync(It.IsAny<RouteContext>()))
+                .Callback<RouteContext>(c =>
+                {
+                    nestedValues = new RouteValueDictionary(c.RouteData.Values);
+                    c.Handler = NullHandler;
+                })
+                .Returns(Task.FromResult(0));
+
+            var builder = CreateBuilder();
+            MapInboundEntry(builder, "cat_{category1}/prod1_{product}"); // Matches on first segment but not on second
+            MapInboundEntry(builder, "cat_{category2}/prod2_{product}", handler: next.Object);
+            var route = builder.Build();
+
+            var context = CreateRouteContext("/cat_examplecategory/prod2_exampleproduct");
+
+            // Act
+            await route.RouteAsync(context);
+
+            // Assert
+            Assert.Equal("examplecategory", nestedValues["category2"]);
+            Assert.Equal("exampleproduct", nestedValues["product"]);
+            Assert.DoesNotContain(nestedValues, kvp => kvp.Key == "category1");
+        }
+
         private static RouteContext CreateRouteContext(string requestPath)
         {
             var request = new Mock<HttpRequest>(MockBehavior.Strict);

--- a/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouterTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouterTest.cs
@@ -1863,7 +1863,7 @@ namespace Microsoft.AspNetCore.Routing.Tree
                     nestedValues = new RouteValueDictionary(c.RouteData.Values);
                     c.Handler = NullHandler;
                 })
-                .Returns(Task.FromResult(0));
+                .Returns(Task.CompletedTask);
 
             var builder = CreateBuilder();
             MapInboundEntry(builder, "cat_{category1}/prod1_{product}"); // Matches on first segment but not on second
@@ -1876,6 +1876,7 @@ namespace Microsoft.AspNetCore.Routing.Tree
             await route.RouteAsync(context);
 
             // Assert
+            Assert.NotNull(nestedValues);
             Assert.Equal("examplecategory", nestedValues["category2"]);
             Assert.Equal("exampleproduct", nestedValues["product"]);
             Assert.DoesNotContain(nestedValues, kvp => kvp.Key == "category1");


### PR DESCRIPTION
Fix for #394.

The issue was that `TreeRouter`'s `RouteAsync` logic was not using its own `snapshot.Restore` feature consistently in between attempting each `matcher`. If a `matcher` failed to match because its 2nd or subsequent complex segment didn't match, then any `RouteValueDictionary` entries populated by the N-1 preceding complex segments were left in place and leaked over into subsequent `matcher` attempts. Depending on whether a subsequent `matcher` tried to use the same key names or not, you'd either get a "*key already present*" exception, or would just leak the internal state from preceding matchers into subsequent ones, neither of which are desirable behaviours.

This fix is pretty trivial: it just ensures that `snapshot.Restore()` is called after each non-matching `matcher.TryMatch`.