### PR TITLE
Fix failing tests

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Resources.resx
+++ b/src/Microsoft.AspNetCore.Routing/Resources.resx
@@ -187,7 +187,7 @@
     <value>In a route parameter, '{' and '}' must be escaped with '{{' and '}}'.</value>
   </data>
   <data name="TemplateRoute_OptionalParameterCanbBePrecededByPeriod" xml:space="preserve">
-    <value>In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'.  Only a period (.) can precede an optional parameter.</value>
+    <value>In the segment '{0}', the optional parameter '{1}' is preceded by an invalid segment '{2}'. Only a period (.) can precede an optional parameter.</value>
   </data>
   <data name="TemplateRoute_OptionalParameterHasTobeTheLast" xml:space="preserve">
     <value>An optional parameter must be at the end of the segment. In the segment '{0}', optional parameter '{1}' is followed by '{2}'.</value>

--- a/src/Microsoft.AspNetCore.Routing/Template/TemplateParser.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/TemplateParser.cs
@@ -342,20 +342,26 @@ namespace Microsoft.AspNetCore.Routing.Template
                     // This optional parameter is the last part in the segment
                     if (i == segment.Parts.Count - 1)
                     {
-                        Debug.Assert(segment.Parts[i - 1].IsLiteral);
-
-                        // the optional parameter is preceded by a period
-                        if (segment.Parts[i - 1].Text == PeriodString)
+                        if(!segment.Parts[i - 1].IsLiteral)
                         {
-                            segment.Parts[i - 1].IsOptionalSeperator = true;
-                        }
-                        else
-                        {
-                            // The optional parameter is preceded by a literal other than period
+                            // The optional parameter is preceded by something that is not a literal.
                             // Example of error message:
-                            // "In the complex segment {RouteValue}-{param?}, the optional parameter 'param'is preceded
-                            // by an invalid segment "-". Only valid literal to precede an optional parameter is a 
-                            // period (.).
+                            // "In the segment '{RouteValue}-{param?}', the optional parameter 'param' is preceded
+                            // by an invalid segment '-'. Only a period (.) can precede an optional parameter.
+                            context.Error = string.Format(
+                                Resources.TemplateRoute_OptionalParameterCanbBePrecededByPeriod,
+                                segment.DebuggerToString(),
+                                part.Name,
+                                segment.Parts[i - 1].DebuggerToString());
+
+                            return false;
+                        }
+                        if(segment.Parts[i - 1].Text != PeriodString)
+                        {
+                            // The optional parameter is preceded by a literal other than period.
+                            // Example of error message:
+                            // "In the segment '{RouteValue}-{param?}', the optional parameter 'param' is preceded
+                            // by an invalid segment '-'. Only a period (.) can precede an optional parameter.
                             context.Error = string.Format(
                                 Resources.TemplateRoute_OptionalParameterCanbBePrecededByPeriod,
                                 segment.DebuggerToString(),
@@ -364,6 +370,7 @@ namespace Microsoft.AspNetCore.Routing.Template
 
                             return false;
                         }
+                        segment.Parts[i - 1].IsOptionalSeperator = true;
                     }
                     else
                     {

--- a/src/Microsoft.AspNetCore.Routing/Template/TemplateParser.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/TemplateParser.cs
@@ -346,8 +346,8 @@ namespace Microsoft.AspNetCore.Routing.Template
                         {
                             // The optional parameter is preceded by something that is not a literal.
                             // Example of error message:
-                            // "In the segment '{RouteValue}-{param?}', the optional parameter 'param' is preceded
-                            // by an invalid segment '-'. Only a period (.) can precede an optional parameter.
+                            // "In the segment '{RouteValue}{param?}', the optional parameter 'param' is preceded
+                            // by an invalid segment '{RouteValue}'. Only a period (.) can precede an optional parameter.
                             context.Error = string.Format(
                                 Resources.TemplateRoute_OptionalParameterCanbBePrecededByPeriod,
                                 segment.DebuggerToString(),

--- a/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateParserTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateParserTests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             Assert.Equal<RouteTemplate>(expected, actual, new TemplateEqualityComparer());
         }
 
-        [Fact(Skip = "Fails")]
+        [Fact]
         public void Parse_ComplexSegment_OptionalParameterFollowingPeriod_LastSegment()
         {
             // Arrange
@@ -420,7 +420,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             expected.Segments.Add(new TemplateSegment());
             expected.Segments[1].Parts.Add(TemplatePart.CreateParameter("p2",
                                                                         false,
-                                                                        true,
+                                                                        false,
                                                                         defaultValue: null,
                                                                         inlineConstraints: null));
             expected.Segments[1].Parts.Add(TemplatePart.CreateLiteral("."));

--- a/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateParserTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateParserTests.cs
@@ -545,19 +545,19 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
                  + Environment.NewLine + "Parameter name: routeTemplate");
         }
 
-        [Theory(Skip = "Skipped because it causes the test framework to crash")]
+        [Theory]
         [InlineData("{p1}-{p2?}", "-")]
         [InlineData("{p1}..{p2?}", "..")]
         [InlineData("..{p2?}", "..")]
         [InlineData("{p1}.abc.{p2?}", ".abc.")]
-        [InlineData("{p1}{p2?}", "p1")]
+        [InlineData("{p1}{p2?}", "{p1}")]
         public void Parse_ComplexSegment_OptionalParametersSeperatedByPeriod_Invalid(string template, string parameter)
         {
             // Act and Assert
             ExceptionAssert.Throws<ArgumentException>(
                 () => TemplateParser.Parse(template),
-                "In the complex segment '"+ template +"',  the optional parameter 'p2' is preceded by an invalid " +
-                "segment '" + parameter +"'. Only valid literal to precede an optional parameter is a period (.)." +
+                "In the segment '"+ template +"', the optional parameter 'p2' is preceded by an invalid " +
+                "segment '" + parameter +"'. Only a period (.) can precede an optional parameter." +
                 Environment.NewLine + "Parameter name: routeTemplate");
         }
 


### PR DESCRIPTION
Fixes issue #407.

One test was failing because the expectation was wrong as far as I can see. I changed the expected part to non-optional instead of optional as that is how it is specified in the template.
The other test that was failing was the xUnit theory with parameters `"{p1}{p2?}", "{p1}"`. It completely crashed the test runner. I found that if I eliminated the `Debug.Assert` in `TemplateParser`, it would go through. The problem was that the preceding part was not a literal at all. I made the assumption that the only thing that can precede an optional part is a literal (which must be a period).