### PR TITLE
Remove TreatWarningsAsErrors from common.props

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -10,7 +10,6 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
- Property is automatically set by Internal.AspNetCore.Sdk