### PR TITLE
Set "TreatWarningsAsErrors" before NuGet restore

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -11,6 +11,7 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Ensures our build stays clean of NuGet warnings