### PR TITLE
Avoid allocation of a new char array on every request in RouteCollection class

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/RouteCollection.cs
+++ b/src/Microsoft.AspNetCore.Routing/RouteCollection.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.Routing
 {
     public class RouteCollection : IRouteCollection
     {
+        private readonly static char[] UrlQueryDelimiters = new char[] { '?', '#' };
         private readonly List<IRouter> _routes = new List<IRouter>();
         private readonly List<IRouter> _unnamedRoutes = new List<IRouter>();
         private readonly Dictionary<string, INamedRouter> _namedRoutes =
@@ -140,7 +141,7 @@ namespace Microsoft.AspNetCore.Routing
 
             if (!string.IsNullOrEmpty(url) && (_options.LowercaseUrls || _options.AppendTrailingSlash))
             {
-                var indexOfSeparator = url.IndexOfAny(new char[] { '?', '#' });
+                var indexOfSeparator = url.IndexOfAny(UrlQueryDelimiters);
                 var urlWithoutQueryString = url;
                 var queryString = string.Empty;
 


### PR DESCRIPTION
This is a **very small micro-optimization**:

When `LowercaseUrls` and/or `AppendTrailingSlash` options are enabled, on every call to `RouteCollection.NormalizeVirtualPath` a `new char[] { '?', '#' }` is being allocated; which happens on every request.

(Does pull request of this _scale_ still require associated issue to exist?)