### PR TITLE
Use previous version of Appveyor image to avoid dotnet bug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,4 +16,4 @@ environment:
 test: off
 deploy: off
 
-os: Visual Studio 2017
+image: Previous Visual Studio 2017


### PR DESCRIPTION
See https://github.com/aspnet/Mvc/pull/7069

Temporary change until the fix ships in the framework