### PR TITLE
Productionize Path tokenization

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerBenchmarkBase.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerBenchmarkBase.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Routing.Matchers
+{
+    public abstract class FastPathTokenizerBenchmarkBase
+    {
+        internal unsafe void NaiveBaseline(string path, PathSegment * segments, int maxCount)
+        {
+            int count = 0;
+            int start = 1; // Paths always start with a leading /
+            int end;
+            while ((end = path.IndexOf('/', start)) >= 0 && count < maxCount)
+            {
+                segments[count++] = new PathSegment(start, end - start);
+                start = end + 1; // resume search after the current character
+            }
+
+            // Residue
+            var length = path.Length - start;
+            if (length > 0 && count < maxCount)
+            {
+                segments[count++] = new PathSegment(start, length);
+            }
+        }
+
+        internal unsafe void MinimalBaseline(string path, PathSegment* segments, int maxCount)
+        {
+            var start = 1;
+            var length = path.Length - start;
+            segments[0] = new PathSegment(start, length);
+        }
+    }
+}

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerEmptyBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerEmptyBenchmark.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Routing.Matchers
+{
+    public class FastPathTokenizerEmptyBenchmark : FastPathTokenizerBenchmarkBase
+    {
+        private const int MaxCount = 32;
+        private static readonly string Input = "/";
+
+        // This is super hardcoded implementation for comparison, we dont't expect to do better.
+        [Benchmark(Baseline = true)]
+        public unsafe void Baseline()
+        {
+            var path = Input;
+            var segments = stackalloc PathSegment[MaxCount];
+
+            MinimalBaseline(path, segments, MaxCount);
+        }
+
+        [Benchmark]
+        public unsafe void Implementation()
+        {
+            var path = Input;
+            var segments = stackalloc PathSegment[MaxCount];
+
+            FastPathTokenizer.Tokenize(path, segments, MaxCount);
+        }
+    }
+}

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerLargeBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerLargeBenchmark.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Routing.Matchers
+{
+    public class FastPathTokenizerLargeBenchmark : FastPathTokenizerBenchmarkBase
+    {
+        private static readonly int MaxCount = 32;
+        private static readonly string Input = 
+            "/heeeeeeeeeeyyyyyyyyyyy/this/is/a/string/with/lots/of/segments" +
+            "/hoooooooooooooooooooooooooooooooooow long/do you think it should be?/I think" +
+            "/like/32/segments/is /a/goood/number/dklfl/20303/dlflkf" +
+            "/Im/tired/of/thinking/of/more/things/to/so";
+
+        // This is a naive reference implementation. We expect to do better.
+        [Benchmark(Baseline = true)]
+        public unsafe void Baseline()
+        {
+            var path = Input;
+            var segments = stackalloc PathSegment[MaxCount];
+
+            NaiveBaseline(path, segments, MaxCount);
+        }
+
+        [Benchmark]
+        public unsafe void Implementation()
+        {
+            var path = Input;
+            var segments = stackalloc PathSegment[MaxCount];
+
+            FastPathTokenizer.Tokenize(path, segments, MaxCount);
+        }
+    }
+}

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerPlaintextBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerPlaintextBenchmark.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Routing.Matchers
+{
+    public class FastPathTokenizerPlaintextBenchmark : FastPathTokenizerBenchmarkBase
+    {
+        private const int MaxCount = 32;
+        private static readonly string Input = "/plaintext";
+
+        // This is super hardcoded implementation for comparison, we dont't expect to do better.
+        [Benchmark(Baseline = true)]
+        public unsafe void Baseline()
+        {
+            var path = Input;
+            var segments = stackalloc PathSegment[MaxCount];
+
+            MinimalBaseline(path, segments, MaxCount);
+        }
+
+        [Benchmark]
+        public unsafe void Implementation()
+        {
+            var path = Input;
+            var segments = stackalloc PathSegment[MaxCount];
+
+            FastPathTokenizer.Tokenize(path, segments, MaxCount);
+        }
+    }
+}

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerSmallBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matchers/FastPathTokenizerSmallBenchmark.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Routing.Matchers
+{
+    public class FastPathTokenizerSmallBenchmark : FastPathTokenizerBenchmarkBase
+    {
+        private const int MaxCount = 32;
+        private static readonly string Input = "/hello/world/cool";
+
+        // This is a naive reference implementation. We expect to do better.
+        [Benchmark(Baseline = true)]
+        public unsafe void Baseline()
+        {
+            var path = Input;
+            var segments = stackalloc PathSegment[MaxCount];
+
+            NaiveBaseline(path, segments, MaxCount);
+        }
+
+        [Benchmark]
+        public unsafe void Implementation()
+        {
+            var path = Input;
+            var segments = stackalloc PathSegment[MaxCount];
+
+            FastPathTokenizer.Tokenize(path, segments, MaxCount);
+        }
+    }
+}

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Microsoft.AspNetCore.Routing.Performance.csproj
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Microsoft.AspNetCore.Routing.Performance.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Microsoft.AspNetCore.Routing/Matchers/FastPathTokenizer.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matchers/FastPathTokenizer.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Routing.Matchers
+{
+    // Low level implementation of our path tokenization algorithm. Alternative
+    // to PathTokenizer.
+    internal static class FastPathTokenizer
+    {
+        // This section tokenizes the path by marking the sequence of slashes, and their
+        // and the length of the text between them.
+        //
+        // If there is residue (text after last slash) then the length of the segment will
+        // computed based on the string length.
+        public static unsafe int Tokenize(string path, PathSegment* segments, int maxCount)
+        {
+            int count = 0;
+            int start = 1; // Paths always start with a leading /
+            int end;
+            var span = path.AsSpan(start);
+            while ((end = span.IndexOf('/')) >= 0 && count < maxCount)
+            {
+                segments[count++] = new PathSegment(start, end);
+                start += end + 1; // resume search after the current character
+                span = path.AsSpan(start);
+            }
+
+            // Residue
+            var length = span.Length;
+            if (length > 0 && count < maxCount)
+            {
+                segments[count++] = new PathSegment(start, length);
+            }
+
+            return count;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/Matchers/PathSegment.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matchers/PathSegment.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Routing.Matchers
+{
+    internal readonly struct PathSegment : IEquatable<PathSegment>
+    {
+        public readonly int Start;
+        public readonly int Length;
+
+        public PathSegment(int start, int length)
+        {
+            Start = start;
+            Length = length;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PathSegment segment ? Equals(segment) : false;
+        }
+
+        public bool Equals(PathSegment other)
+        {
+            return Start == other.Start && Length == other.Length;
+        }
+
+        public override int GetHashCode()
+        {
+            return Start;
+        }
+
+        public override string ToString()
+        {
+            return $"Segment({Start}:{Length})";
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/Microsoft.AspNetCore.Routing.csproj
+++ b/src/Microsoft.AspNetCore.Routing/Microsoft.AspNetCore.Routing.csproj
@@ -8,6 +8,7 @@ Microsoft.AspNetCore.Routing.RouteCollection</Description>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;routing</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.AspNetCore.Routing.Tests/Matchers/FastPathTokenizerTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Matchers/FastPathTokenizerTest.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Routing.Matchers
+{
+    public unsafe class FastPathTokenizerTest
+    {
+        [Fact] // Note: tokenizing a truly empty string is undefined.
+        public void Tokenize_EmptyPath()
+        {
+            // Arrange
+            var segments = stackalloc PathSegment[32];
+
+            // Act
+            var count = FastPathTokenizer.Tokenize("/", segments, 1);
+
+            // Assert
+            Assert.Equal(0, count);
+        }
+
+        [Fact]
+        public void Tokenize_SingleSegment()
+        {
+            // Arrange
+            var segments = stackalloc PathSegment[32];
+
+            // Act
+            var count = FastPathTokenizer.Tokenize("/abc", segments, 1);
+
+            // Assert
+            Assert.Equal(1, count);
+            Assert.Equal(new PathSegment(1, 3), segments[0]);
+        }
+
+        [Fact]
+        public void Tokenize_WithSomeSegments()
+        {
+            // Arrange
+            var segments = stackalloc PathSegment[32];
+
+            // Act
+            var count = FastPathTokenizer.Tokenize("/a/b/c", segments, 3);
+
+            // Assert
+            Assert.Equal(3, count);
+            Assert.Equal(new PathSegment(1, 1), segments[0]);
+            Assert.Equal(new PathSegment(3, 1), segments[1]);
+            Assert.Equal(new PathSegment(5, 1), segments[2]);
+        }
+
+        [Fact] // Empty trailing / is ignored
+        public void Tokenize_WithSomeSegments_TrailingSlash()
+        {
+            // Arrange
+            var segments = stackalloc PathSegment[32];
+
+            // Act
+            var count = FastPathTokenizer.Tokenize("/a/b/c/", segments, 3);
+
+            // Assert
+            Assert.Equal(3, count);
+            Assert.Equal(new PathSegment(1, 1), segments[0]);
+            Assert.Equal(new PathSegment(3, 1), segments[1]);
+            Assert.Equal(new PathSegment(5, 1), segments[2]);
+        }
+
+        [Fact]
+        public void Tokenize_LongerSegments()
+        {
+            // Arrange
+            var segments = stackalloc PathSegment[32];
+
+            // Act
+            var count = FastPathTokenizer.Tokenize("/aaa/bb/ccccc", segments, 3);
+
+            // Assert
+            Assert.Equal(3, count);
+            Assert.Equal(new PathSegment(1, 3), segments[0]);
+            Assert.Equal(new PathSegment(5, 2), segments[1]);
+            Assert.Equal(new PathSegment(8, 5), segments[2]);
+        }
+
+        [Fact]
+        public void Tokenize_EmptySegments()
+        {
+            // Arrange
+            var segments = stackalloc PathSegment[32];
+
+            // Act
+            var count = FastPathTokenizer.Tokenize("///c", segments, 3);
+
+            // Assert
+            Assert.Equal(3, count);
+            Assert.Equal(new PathSegment(1, 0), segments[0]);
+            Assert.Equal(new PathSegment(2, 0), segments[1]);
+            Assert.Equal(new PathSegment(3, 1), segments[2]);
+        }
+
+        [Fact]
+        public void Tokenize_TooManySegments()
+        {
+            // Arrange
+            var segments = stackalloc PathSegment[32];
+
+            // Act
+            var count = FastPathTokenizer.Tokenize("/a/b/c/d", segments, 3);
+
+            // Assert
+            Assert.Equal(3, count);
+            Assert.Equal(new PathSegment(1, 1), segments[0]);
+            Assert.Equal(new PathSegment(3, 1), segments[1]);
+            Assert.Equal(new PathSegment(5, 1), segments[2]);
+        }
+    }
+}


### PR DESCRIPTION
/cc @JamesNK @kichalla - extracting a piece of the experimental matchers that's pretty well defined and stable. 

I'm changing the project to target 2.2 to make it easier to profile. The actual benchmarks run under 2.2 - except when you profile, which is annoying. 

|         Method |     Mean |      Error |     StdDev |        Op/s | Scaled | ScaledSD | Allocated |
|--------------- |---------:|-----------:|-----------:|------------:|-------:|---------:|----------:|
|       Baseline | 714.6 ns | 14.0602 ns | 17.7817 ns | 1,399,364.1 |   1.00 |     0.00 |       0 B |
| Implementation | 473.2 ns |  0.6469 ns |  0.4677 ns | 2,113,265.0 |   0.66 |     0.02 |       0 B |