### PR TITLE
[automated] Infrastructure updates for release/2.2

### DIFF
--- a/.vsts-pipelines/builds/ci-internal.yml
+++ b/.vsts-pipelines/builds/ci-internal.yml
@@ -1,5 +1,5 @@
 trigger:
-- dev
+- master
 - release/*
 
 resources:
@@ -7,7 +7,7 @@ resources:
   - repository: buildtools
     type: git
     name: aspnet-BuildTools
-    ref: refs/heads/dev
+    ref: refs/heads/release/2.2
 
 phases:
 - template: .vsts-pipelines/templates/project-ci.yml@buildtools

--- a/.vsts-pipelines/builds/ci-public.yml
+++ b/.vsts-pipelines/builds/ci-public.yml
@@ -1,5 +1,5 @@
 trigger:
-- dev
+- master
 - release/*
 
 # See https://github.com/aspnet/BuildTools
@@ -9,7 +9,7 @@ resources:
     type: github
     endpoint: DotNet-Bot GitHub Connection
     name: aspnet/BuildTools
-    ref: refs/heads/dev
-    
+    ref: refs/heads/release/2.2
+
 phases:
 - template: .vsts-pipelines/templates/project-ci.yml@buildtools

--- a/benchmarkapps/Benchmarks/benchmarks.json
+++ b/benchmarkapps/Benchmarks/benchmarks.json
@@ -8,7 +8,7 @@
     },
     "Source": {
       "Repository": "https://github.com/aspnet/routing.git",
-      "BranchOrCommit": "dev",
+      "BranchOrCommit": "release/2.2",
       "Project": "benchmarkapps/Benchmarks/Benchmarks.csproj"
     },
     "Port": 8080

--- a/build/repo.props
+++ b/build/repo.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <!-- These properties are use by the automation that updates dependencies.props -->
     <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>
+    <LineupPackageVersion>2.2.0-*</LineupPackageVersion>
     <LineupPackageRestoreSource>https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</LineupPackageRestoreSource>
   </PropertyGroup>
 

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/dev/tools/korebuild.schema.json",
-  "channel": "dev"
+  "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/release/2.2/tools/korebuild.schema.json",
+  "channel": "release/2.2"
 }


### PR DESCRIPTION
Part of https://github.com/aspnet/Home/issues/3278.
This should update lineups, korebuild config, and CI devs to use the release/2.2 channel.