### PR TITLE
Added support for configuring route options with LinkGenerator

### DIFF
--- a/src/Microsoft.AspNetCore.Routing.Abstractions/LinkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Routing.Abstractions/LinkGenerator.cs
@@ -1,24 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Routing
 {
     public abstract class LinkGenerator
     {
-        public abstract bool TryGetLink(
-            HttpContext httpContext,
-            IEnumerable<Endpoint> endpoints,
-            RouteValueDictionary explicitValues,
-            RouteValueDictionary ambientValues,
-            out string link);
+        public abstract bool TryGetLink(LinkGeneratorContext context, out string link);
 
-        public abstract string GetLink(
-            HttpContext httpContext,
-            IEnumerable<Endpoint> endpoints,
-            RouteValueDictionary explicitValues,
-            RouteValueDictionary ambientValues);
+        public abstract string GetLink(LinkGeneratorContext context);
     }
 }

--- a/src/Microsoft.AspNetCore.Routing.Abstractions/LinkGeneratorContext.cs
+++ b/src/Microsoft.AspNetCore.Routing.Abstractions/LinkGeneratorContext.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Routing
+{
+    public class LinkGeneratorContext
+    {
+        public HttpContext HttpContext { get; set; }
+
+        public IEnumerable<Endpoint> Endpoints { get; set; }
+
+        public RouteValueDictionary ExplicitValues { get; set; }
+
+        public RouteValueDictionary AmbientValues { get; set; }
+
+        public bool? LowercaseUrls { get; set; }
+
+        public bool? LowercaseQueryStrings { get; set; }
+
+        public bool? AppendTrailingSlash { get; set; }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
@@ -11,32 +11,38 @@ using Microsoft.AspNetCore.Routing.Matchers;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ObjectPool;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Routing
 {
     internal class DefaultLinkGenerator : LinkGenerator
     {
+        private readonly static char[] UrlQueryDelimiters = new char[] { '?', '#' };
         private readonly MatchProcessorFactory _matchProcessorFactory;
         private readonly ObjectPool<UriBuildingContext> _uriBuildingContextPool;
+        private readonly RouteOptions _options;
         private readonly ILogger<DefaultLinkGenerator> _logger;
 
         public DefaultLinkGenerator(
             MatchProcessorFactory matchProcessorFactory,
             ObjectPool<UriBuildingContext> uriBuildingContextPool,
+            IOptions<RouteOptions> options,
             ILogger<DefaultLinkGenerator> logger)
         {
             _matchProcessorFactory = matchProcessorFactory;
             _uriBuildingContextPool = uriBuildingContextPool;
+            _options = options.Value;
             _logger = logger;
         }
 
-        public override string GetLink(
-            HttpContext httpContext,
-            IEnumerable<Endpoint> endpoints,
-            RouteValueDictionary explicitValues,
-            RouteValueDictionary ambientValues)
+        public override string GetLink(LinkGeneratorContext context)
         {
-            if (TryGetLink(httpContext, endpoints, explicitValues, ambientValues, out var link))
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (TryGetLink(context, out var link))
             {
                 return link;
             }
@@ -44,21 +50,21 @@ namespace Microsoft.AspNetCore.Routing
             throw new InvalidOperationException("Could not find a matching endpoint to generate a link.");
         }
 
-        public override bool TryGetLink(
-            HttpContext httpContext,
-            IEnumerable<Endpoint> endpoints,
-            RouteValueDictionary explicitValues,
-            RouteValueDictionary ambientValues,
-            out string link)
+        public override bool TryGetLink(LinkGeneratorContext context, out string link)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
             link = null;
 
-            if (endpoints == null)
+            if (context.Endpoints == null)
             {
                 return false;
             }
 
-            var matcherEndpoints = endpoints.OfType<MatcherEndpoint>();
+            var matcherEndpoints = context.Endpoints.OfType<MatcherEndpoint>();
             if (!matcherEndpoints.Any())
             {
                 //todo:log here
@@ -67,7 +73,7 @@ namespace Microsoft.AspNetCore.Routing
 
             foreach (var endpoint in matcherEndpoints)
             {
-                link = GetLink(httpContext, endpoint, explicitValues, ambientValues);
+                link = GetLink(endpoint, context);
                 if (link != null)
                 {
                     return true;
@@ -77,11 +83,7 @@ namespace Microsoft.AspNetCore.Routing
             return false;
         }
 
-        private string GetLink(
-            HttpContext httpContext,
-            MatcherEndpoint endpoint,
-            RouteValueDictionary explicitValues,
-            RouteValueDictionary ambientValues)
+        private string GetLink(MatcherEndpoint endpoint, LinkGeneratorContext context)
         {
             var templateBinder = new TemplateBinder(
                 UrlEncoder.Default,
@@ -89,22 +91,28 @@ namespace Microsoft.AspNetCore.Routing
                 endpoint.ParsedTemplate,
                 endpoint.Defaults);
 
-            var templateValuesResult = templateBinder.GetValues(ambientValues, explicitValues);
+            var templateValuesResult = templateBinder.GetValues(
+                ambientValues: context.AmbientValues,
+                values: context.ExplicitValues);
             if (templateValuesResult == null)
             {
                 // We're missing one of the required values for this route.
                 return null;
             }
 
-            if (!Match(httpContext, endpoint, templateValuesResult.CombinedValues))
+            if (!MatchesConstraints(context.HttpContext, endpoint, templateValuesResult.CombinedValues))
             {
                 return null;
             }
 
-            return templateBinder.BindValues(templateValuesResult.AcceptedValues);
+            var url = templateBinder.BindValues(templateValuesResult.AcceptedValues);
+            return Normalize(context, url);
         }
 
-        private bool Match(HttpContext httpContext, MatcherEndpoint endpoint, RouteValueDictionary routeValues)
+        private bool MatchesConstraints(
+            HttpContext httpContext,
+            MatcherEndpoint endpoint,
+            RouteValueDictionary routeValues)
         {
             if (routeValues == null)
             {
@@ -128,6 +136,48 @@ namespace Microsoft.AspNetCore.Routing
             }
 
             return true;
+        }
+
+        private string Normalize(LinkGeneratorContext context, string url)
+        {
+            var lowercaseUrls = context.LowercaseUrls.HasValue ? context.LowercaseUrls.Value : _options.LowercaseUrls;
+            var lowercaseQueryStrings = context.LowercaseQueryStrings.HasValue ?
+                context.LowercaseQueryStrings.Value : _options.LowercaseQueryStrings;
+            var appendTrailingSlash = context.AppendTrailingSlash.HasValue ?
+                context.AppendTrailingSlash.Value : _options.AppendTrailingSlash;
+
+            if (!string.IsNullOrEmpty(url) && (lowercaseUrls || appendTrailingSlash))
+            {
+                var indexOfSeparator = url.IndexOfAny(UrlQueryDelimiters);
+                var urlWithoutQueryString = url;
+                var queryString = string.Empty;
+
+                if (indexOfSeparator != -1)
+                {
+                    urlWithoutQueryString = url.Substring(0, indexOfSeparator);
+                    queryString = url.Substring(indexOfSeparator);
+                }
+
+                if (lowercaseUrls)
+                {
+                    urlWithoutQueryString = urlWithoutQueryString.ToLowerInvariant();
+                }
+
+                if (lowercaseUrls && lowercaseQueryStrings)
+                {
+                    queryString = queryString.ToLowerInvariant();
+                }
+
+                if (appendTrailingSlash && !urlWithoutQueryString.EndsWith("/", StringComparison.Ordinal))
+                {
+                    urlWithoutQueryString += "/";
+                }
+
+                // queryString will contain the delimiter ? or # as the first character, so it's safe to append.
+                url = urlWithoutQueryString + queryString;
+            }
+
+            return url;
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Routing/RouteOptions.cs
+++ b/src/Microsoft.AspNetCore.Routing/RouteOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Routing
 
         /// <summary>
         /// Gets or sets a value indicating whether a generated query strings are lower-case.
-        /// This property will be unless <see cref="LowercaseUrls" /> is also <c>true</c>
+        /// This property will not be used unless <see cref="LowercaseUrls" /> is also <c>true</c>.
         /// </summary>
         public bool LowercaseQueryStrings { get; set; }
 

--- a/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
@@ -31,10 +31,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home", link);
@@ -52,10 +54,12 @@ namespace Microsoft.AspNetCore.Routing
             // Act & Assert
             var exception = Assert.Throws<InvalidOperationException>(
                 () => linkGenerator.GetLink(
-                    httpContext: null,
-                    new[] { endpoint },
-                    context.ExplicitValues,
-                    context.AmbientValues));
+                    new LinkGeneratorContext
+                    {
+                        Endpoints = new[] { endpoint },
+                        ExplicitValues = context.ExplicitValues,
+                        AmbientValues = context.AmbientValues
+                    }));
             Assert.Equal(expectedMessage, exception.Message);
         }
 
@@ -69,10 +73,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -92,10 +98,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint1, endpoint2, endpoint3 },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint1, endpoint2, endpoint3 },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/10", link);
@@ -113,10 +121,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint1, endpoint2, endpoint3 },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint1, endpoint2, endpoint3 },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index", link);
@@ -134,10 +144,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index?name=name%20with%20%25special%20%23characters", link);
@@ -155,10 +167,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index?color=red&color=green&color=blue", link);
@@ -176,10 +190,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index?items=10&items=20&items=30", link);
@@ -197,10 +213,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index", link);
@@ -218,10 +236,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index?page=1&color=red&color=green&color=blue&message=textfortest", link);
@@ -239,15 +259,258 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index", link);
         }
 
+        [Fact]
+        public void GetLink_GeneratesLowercaseUrl_SetOnRouteOptions()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(new RouteOptions() { LowercaseUrls = true });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "Index" },
+                ambientValues: new { controller = "Home" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
+
+            // Assert
+            Assert.Equal("/home/index", link);
+        }
+
+        [Fact]
+        public void GetLink_GeneratesLowercaseQueryString_SetOnRouteOptions()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(
+                new RouteOptions() { LowercaseUrls = true, LowercaseQueryStrings = true });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "Index", ShowStatus = "True", INFO = "DETAILED" },
+                ambientValues: new { controller = "Home" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
+
+            // Assert
+            Assert.Equal("/home/index?showstatus=true&info=detailed", link);
+        }
+
+        [Fact]
+        public void GetLink_GeneratesLowercaseQueryString_OnlyIfLowercaseUrlIsTrue_SetOnRouteOptions()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(
+                new RouteOptions() { LowercaseUrls = false, LowercaseQueryStrings = true });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "Index", ShowStatus = "True", INFO = "DETAILED" },
+                ambientValues: new { controller = "Home" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
+
+            // Assert
+            Assert.Equal("/Home/Index?ShowStatus=True&INFO=DETAILED", link);
+        }
+
+        [Fact]
+        public void GetLink_AppendsTrailingSlash_SetOnRouteOptions()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(new RouteOptions() { AppendTrailingSlash = true });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "Index" },
+                ambientValues: new { controller = "Home" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
+
+            // Assert
+            Assert.Equal("/Home/Index/", link);
+        }
+
+        [Fact]
+        public void GetLink_GeneratesLowercaseQueryStringAndTrailingSlash_SetOnRouteOptions()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(
+                new RouteOptions() { LowercaseUrls = true, LowercaseQueryStrings = true, AppendTrailingSlash = true });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "Index", ShowStatus = "True", INFO = "DETAILED" },
+                ambientValues: new { controller = "Home" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
+
+            // Assert
+            Assert.Equal("/home/index/?showstatus=true&info=detailed", link);
+        }
+
+        [Fact]
+        public void GetLink_LowercaseUrlSetToTrue_OnRouteOptions_OverridenByCallsiteValue()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(new RouteOptions() { LowercaseUrls = true });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "InDex" },
+                ambientValues: new { controller = "HoMe" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues,
+                    LowercaseUrls = false
+                });
+
+            // Assert
+            Assert.Equal("/HoMe/InDex", link);
+        }
+
+        [Fact]
+        public void GetLink_LowercaseUrlSetToFalse_OnRouteOptions_OverridenByCallsiteValue()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(new RouteOptions() { LowercaseUrls = false });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "InDex" },
+                ambientValues: new { controller = "HoMe" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues,
+                    LowercaseUrls = true
+                });
+
+            // Assert
+            Assert.Equal("/home/index", link);
+        }
+
+        [Fact]
+        public void GetLink_LowercaseUrlQueryStringsSetToTrue_OnRouteOptions_OverridenByCallsiteValue()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(
+                new RouteOptions() { LowercaseUrls = true, LowercaseQueryStrings = true });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "Index", ShowStatus = "True", INFO = "DETAILED" },
+                ambientValues: new { controller = "Home" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues,
+                    LowercaseUrls = false,
+                    LowercaseQueryStrings = false
+                });
+
+            // Assert
+            Assert.Equal("/Home/Index?ShowStatus=True&INFO=DETAILED", link);
+        }
+
+        [Fact]
+        public void GetLink_LowercaseUrlQueryStringsSetToFalse_OnRouteOptions_OverridenByCallsiteValue()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(
+                new RouteOptions() { LowercaseUrls = false, LowercaseQueryStrings = false });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "Index", ShowStatus = "True", INFO = "DETAILED" },
+                ambientValues: new { controller = "Home" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues,
+                    LowercaseUrls = true,
+                    LowercaseQueryStrings = true
+                });
+
+            // Assert
+            Assert.Equal("/home/index?showstatus=true&info=detailed", link);
+        }
+
+        [Fact]
+        public void GetLink_AppendTrailingSlashSetToFalse_OnRouteOptions_OverridenByCallsiteValue()
+        {
+            // Arrange
+            var endpoint = CreateEndpoint("{controller}/{action}");
+            var linkGenerator = CreateLinkGenerator(new RouteOptions() { AppendTrailingSlash = false });
+            var context = CreateRouteValuesContext(
+                suppliedValues: new { action = "Index" },
+                ambientValues: new { controller = "Home" });
+
+            // Act
+            var link = linkGenerator.GetLink(
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues,
+                    AppendTrailingSlash = true
+                });
+
+            // Assert
+            Assert.Equal("/Home/Index/", link);
+        }
         [Fact]
         public void RouteGenerationRejectsConstraints()
         {
@@ -756,10 +1019,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/products", link);
@@ -776,10 +1041,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index", link);
@@ -798,10 +1065,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/products", link);
@@ -820,10 +1089,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index", link);
@@ -840,10 +1111,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/products?format=json", link);
@@ -903,10 +1176,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index", link);
@@ -1007,13 +1282,16 @@ namespace Microsoft.AspNetCore.Routing
                 null);
         }
 
-        private LinkGenerator CreateLinkGenerator()
+        private LinkGenerator CreateLinkGenerator(RouteOptions routeOptions = null)
         {
+            routeOptions = routeOptions ?? new RouteOptions();
+            var options = Options.Create(routeOptions);
             return new DefaultLinkGenerator(
                 new DefaultMatchProcessorFactory(
-                    Options.Create(new RouteOptions()),
+                    options,
                     Mock.Of<IServiceProvider>()),
                 new DefaultObjectPool<UriBuildingContext>(new UriBuilderContextPooledObjectPolicy()),
+                options,
                 NullLogger<DefaultLinkGenerator>.Instance);
         }
     }

--- a/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
@@ -511,6 +511,7 @@ namespace Microsoft.AspNetCore.Routing
             // Assert
             Assert.Equal("/Home/Index/", link);
         }
+
         [Fact]
         public void RouteGenerationRejectsConstraints()
         {
@@ -526,10 +527,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -551,10 +555,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -577,10 +584,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -602,10 +612,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -641,10 +654,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -678,10 +694,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -715,10 +734,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/slug/Home/Store", link);
@@ -749,10 +771,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/slug/Shopping", link);
@@ -784,10 +809,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/slug/Home/Store", link);
@@ -811,10 +839,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/4", link);
@@ -837,10 +868,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -864,10 +898,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/98", link);
@@ -890,10 +927,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index", link);
@@ -916,10 +956,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -944,10 +987,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/14", link);
@@ -971,10 +1017,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var canGenerateLink = linkGenerator.TryGetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues,
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                },
                 out var link);
 
             // Assert
@@ -999,10 +1048,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/products", link);
@@ -1135,10 +1187,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/.products", link);
@@ -1156,10 +1211,13 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                new DefaultHttpContext(),
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/Home/Index/", link);
@@ -1199,10 +1257,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/a/15/17", link);
@@ -1220,10 +1280,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/a/15/17", link);
@@ -1241,10 +1303,12 @@ namespace Microsoft.AspNetCore.Routing
 
             // Act
             var link = linkGenerator.GetLink(
-                httpContext: null,
-                new[] { endpoint },
-                context.ExplicitValues,
-                context.AmbientValues);
+                new LinkGeneratorContext
+                {
+                    Endpoints = new[] { endpoint },
+                    ExplicitValues = context.ExplicitValues,
+                    AmbientValues = context.AmbientValues
+                });
 
             // Assert
             Assert.Equal("/a", link);


### PR DESCRIPTION
[Fixes #547] Link generation: Expose options to configure link generation at the call site and globally