### PR TITLE
Add support for GraphViz

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/DependencyInjection/RoutingServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Routing/DependencyInjection/RoutingServiceCollectionExtensions.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.TryAddSingleton<MatchProcessorFactory, DefaultMatchProcessorFactory>();
             services.TryAddSingleton<MatcherFactory, DfaMatcherFactory>();
             services.TryAddTransient<DfaMatcherBuilder>();
+            services.TryAddSingleton<DfaGraphWriter>();
 
             // Link generation related services
             services.TryAddSingleton<IEndpointFinder<RouteValuesAddress>, RouteValuesBasedEndpointFinder>();

--- a/src/Microsoft.AspNetCore.Routing/Internal/DfaGraphWriter.cs
+++ b/src/Microsoft.AspNetCore.Routing/Internal/DfaGraphWriter.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.AspNetCore.Routing.Matching;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Routing.Internal
+{
+    /// <summary>
+    /// <para>
+    /// A singleton service that can be used to write the route table as a state machine
+    /// in GraphViz DOT language https://www.graphviz.org/doc/info/lang.html
+    /// </para>
+    /// <para>
+    /// You can use http://www.webgraphviz.com/ to visualize the results.
+    /// </para>
+    /// <para>
+    /// This type has no support contract, and may be removed or changed at any time in
+    /// a future release.
+    /// </para>
+    /// </summary>
+    public class DfaGraphWriter
+    {
+        private readonly IServiceProvider _services;
+
+        public DfaGraphWriter(IServiceProvider services)
+        {
+            _services = services;
+        }
+
+        public void Write(EndpointDataSource dataSource, TextWriter writer)
+        {
+            var builder = _services.GetRequiredService<DfaMatcherBuilder>();
+
+            var endpoints = dataSource.Endpoints;
+            for (var i = 0; i < endpoints.Count; i++)
+            {
+                var endpoint = endpoints[i] as MatcherEndpoint;
+                if (endpoint != null)
+                {
+                    builder.AddEndpoint(endpoint);
+                }
+            }
+
+            // Assign each node a sequential index.
+            var visited = new Dictionary<DfaNode, int>();
+            
+            var tree = builder.BuildDfaTree();
+
+            writer.WriteLine("digraph DFA {");
+            tree.Visit(WriteNode);
+            writer.WriteLine("}");
+
+            void WriteNode(DfaNode node)
+            {
+                if (!visited.TryGetValue(node, out var label))
+                {
+                    label = visited.Count;
+                    visited.Add(node, label);
+                }
+
+                // We can safely index into visited because this is a post-order traversal,
+                // all of the children of this node are already in the dictionary.
+
+                foreach (var literal in node.Literals)
+                {
+                    writer.WriteLine($"{label} -> {visited[literal.Value]} [label=\"/{literal.Key}\"]");
+                }
+
+                if (node.Parameters != null)
+                {
+                    writer.WriteLine($"{label} -> {visited[node.Parameters]} [label=\"/*\"]");
+                }
+
+                if (node.CatchAll != null && node.Parameters != node.CatchAll)
+                {
+                    writer.WriteLine($"{label} -> {visited[node.CatchAll]} [label=\"/**\"]");
+                }
+
+                foreach (var policy in node.PolicyEdges)
+                {
+                    writer.WriteLine($"{label} -> {visited[policy.Value]} [label=\"{policy.Key}\"]");
+                }
+
+                writer.WriteLine($"{label} [label=\"{node.Label}\"]");
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
@@ -534,7 +534,10 @@ namespace Microsoft.AspNetCore.Routing.Matching
                     {
                         var edge = edges[k];
 
-                        var next = new DfaNode();
+                        var next = new DfaNode()
+                        {
+                            Label = parent.Label + " " + edge.State.ToString(),
+                        };
 
                         // TODO: https://github.com/aspnet/Routing/issues/648
                         next.Matches.AddRange(edge.Endpoints.Cast<MatcherEndpoint>().ToArray());

--- a/src/Microsoft.AspNetCore.Routing/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/HttpMethodMatcherPolicy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -366,6 +367,12 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 hash.Add(IsCorsPreflightRequest);
                 hash.Add(HttpMethod, StringComparer.Ordinal);
                 return hash;
+            }
+
+            // Used in GraphViz output.
+            public override string ToString()
+            {
+                return IsCorsPreflightRequest ? $"CORS: {HttpMethod}" : $"HTTP: {HttpMethod}";
             }
         }
     }


### PR DESCRIPTION
Adds **internal** support for dumping a route table to GraphViz DOT
notation. This allows us to dump the DFA graph for a route table and
visualize it.

Example:
https://gist.github.com/rynowak/2b24e4a6a602ca6f9c4de3ec227d621b