### PR TITLE
use short

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/CustomHashTableJumpTable.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/CustomHashTableJumpTable.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
             for (var i = 0; i < entries.Length; i++)
             {
-                var key = GetKey(entries[i].text, new PathSegment(0, entries[i].text.Length));
+                var key = GetKey(entries[i].text, new PathSegment((short)0, (short)entries[i].text.Length));
                 if (!map.TryGetValue(key, out var matches))
                 {
                     matches = new List<(string text, int destination)>();

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/FastPathTokenizerBenchmarkBase.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/FastPathTokenizerBenchmarkBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             int end;
             while ((end = path.IndexOf('/', start)) >= 0 && count < maxCount)
             {
-                segments[count++] = new PathSegment(start, end - start);
+                segments[count++] = new PathSegment((short)start, (short)(end - start));
                 start = end + 1; // resume search after the current character
             }
 
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var length = path.Length - start;
             if (length > 0 && count < maxCount)
             {
-                segments[count++] = new PathSegment(start, length);
+                segments[count++] = new PathSegment((short)start, (short)length);
             }
         }
 
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         {
             var start = 1;
             var length = path.Length - start;
-            segments[0] = new PathSegment(start, length);
+            segments[0] = new PathSegment((short)start, (short)length);
         }
     }
 }

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/JumpTableMultipleEntryBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/JumpTableMultipleEntryBenchmark.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
             for (var i = 0; i < _strings.Length; i++)
             {
-                _segments[i] = new PathSegment(0, _strings[i].Length);
+                _segments[i] = new PathSegment((short)0, (short)_strings[i].Length);
             }
 
             var samples = new int[Count];

--- a/src/Microsoft.AspNetCore.Routing/Matching/FastPathTokenizer.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/FastPathTokenizer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var span = path.AsSpan(start);
             while ((end = span.IndexOf('/')) >= 0 && count < segments.Length)
             {
-                segments[count++] = new PathSegment(start, end);
+                segments[count++] = new PathSegment((short)start, (short)end);
                 start += end + 1; // resume search after the current character
                 span = path.AsSpan(start);
             }
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var length = span.Length;
             if (length > 0 && count < segments.Length)
             {
-                segments[count++] = new PathSegment(start, length);
+                segments[count++] = new PathSegment((short)start, (short)length);
             }
 
             return count;

--- a/src/Microsoft.AspNetCore.Routing/Matching/PathSegment.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/PathSegment.cs
@@ -7,10 +7,10 @@ namespace Microsoft.AspNetCore.Routing.Matching
 {
     internal readonly struct PathSegment : IEquatable<PathSegment>
     {
-        public readonly int Start;
-        public readonly int Length;
+        public readonly short Start;
+        public readonly short Length;
 
-        public PathSegment(int start, int length)
+        public PathSegment(short start, short length)
         {
             Start = start;
             Length = length;


### PR DESCRIPTION
Uses short for PathSegment. Results for plaintext microbenchmark

**Before**

```
           Method |       Mean |     Error |    StdDev |        Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
----------------- |-----------:|----------:|----------:|------------:|-------:|---------:|-------:|----------:|
         Baseline |   181.8 ns |  1.692 ns |  1.413 ns | 5,501,495.5 |   1.00 |     0.00 | 0.0002 |      40 B |
              Dfa |   317.2 ns |  6.213 ns |  7.155 ns | 3,152,332.2 |   1.75 |     0.04 | 0.0010 |     168 B |
 LegacyTreeRouter | 2,451.0 ns | 16.982 ns | 15.054 ns |   407,990.9 |  13.49 |     0.13 |      - |     480 B |
     LegacyRouter | 1,345.2 ns | 14.328 ns | 11.964 ns |   743,363.7 |   7.40 |     0.08 | 0.0019 |     344 B |
```

**After**

```
           Method |       Mean |     Error |    StdDev |        Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
----------------- |-----------:|----------:|----------:|------------:|-------:|---------:|-------:|----------:|
         Baseline |   184.8 ns |  3.759 ns |  3.516 ns | 5,411,169.6 |   1.00 |     0.00 | 0.0002 |      40 B |
              Dfa |   312.5 ns |  2.708 ns |  2.262 ns | 3,199,525.4 |   1.69 |     0.03 | 0.0010 |     168 B |
 LegacyTreeRouter | 2,167.9 ns | 15.722 ns | 14.706 ns |   461,275.4 |  11.73 |     0.22 |      - |     480 B |
     LegacyRouter | 1,476.3 ns | 28.429 ns | 26.593 ns |   677,351.5 |   7.99 |     0.20 | 0.0019 |     344 B |
```

int16.MaxValue is 32k so that's plenty of space for the URL sizes we allow.