### PR TITLE
 Optimize RoutePattern allocations

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePattern.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePattern.cs
@@ -21,10 +21,10 @@ namespace Microsoft.AspNetCore.Routing.Patterns
 
         internal RoutePattern(
             string rawText,
-            Dictionary<string, object> defaults,
-            Dictionary<string, IReadOnlyList<RoutePatternConstraintReference>> constraints,
-            RoutePatternParameterPart[] parameters,
-            RoutePatternPathSegment[] pathSegments)
+            IReadOnlyDictionary<string, object> defaults,
+            IReadOnlyDictionary<string, IReadOnlyList<RoutePatternConstraintReference>> constraints,
+            IReadOnlyList<RoutePatternParameterPart> parameters,
+            IReadOnlyList<RoutePatternPathSegment> pathSegments)
         {
             Debug.Assert(defaults != null);
             Debug.Assert(constraints != null);

--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternFactory.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternFactory.cs
@@ -246,12 +246,6 @@ namespace Microsoft.AspNetCore.Routing.Patterns
             IDictionary<string, object> constraints,
             IEnumerable<RoutePatternPathSegment> segments)
         {
-            if ((defaults == null || defaults.Count == 0)
-                && (constraints == null || constraints.Count == 0))
-            {
-
-            }
-
             // We want to merge the segment data with the 'out of line' defaults and constraints.
             //
             // This means that for parameters that have 'out of line' defaults we will modify

--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternFactory.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternFactory.cs
@@ -373,7 +373,7 @@ namespace Microsoft.AspNetCore.Routing.Patterns
                     parameterConstraints.AddRange(parameter.Constraints);
                 }
 
-                if (parameter.Default == @default
+                if (Equals(parameter.Default, @default)
                     && parameter.Constraints.Count == 0
                     && (parameterConstraints?.Count ?? 0) == 0)
                 {

--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternFactory.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternFactory.cs
@@ -303,11 +303,27 @@ namespace Microsoft.AspNetCore.Routing.Patterns
 
             RoutePatternPathSegment VisitSegment(RoutePatternPathSegment segment)
             {
-                var updatedParts = new RoutePatternPart[segment.Parts.Count];
+                RoutePatternPart[] updatedParts = null;
                 for (var i = 0; i < segment.Parts.Count; i++)
                 {
                     var part = segment.Parts[i];
-                    updatedParts[i] = VisitPart(part);
+                    var updatedPart = VisitPart(part);
+
+                    if (part != updatedPart)
+                    {
+                        if (updatedParts == null)
+                        {
+                            updatedParts = segment.Parts.ToArray();
+                        }
+
+                        updatedParts[i] = updatedPart;
+                    }
+                }
+
+                if (updatedParts == null)
+                {
+                    // Segment has not changed
+                    return segment;
                 }
 
                 return new RoutePatternPathSegment(updatedParts);
@@ -355,6 +371,14 @@ namespace Microsoft.AspNetCore.Routing.Patterns
                 if (parameter.Constraints.Count > 0)
                 {
                     parameterConstraints.AddRange(parameter.Constraints);
+                }
+
+                if (parameter.Default == @default
+                    && parameter.Constraints.Count == 0
+                    && (parameterConstraints?.Count ?? 0) == 0)
+                {
+                    // Part has not changed
+                    return part;
                 }
 
                 return ParameterPartCore(

--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternFactory.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternFactory.cs
@@ -246,6 +246,12 @@ namespace Microsoft.AspNetCore.Routing.Patterns
             IDictionary<string, object> constraints,
             IEnumerable<RoutePatternPathSegment> segments)
         {
+            if ((defaults == null || defaults.Count == 0)
+                && (constraints == null || constraints.Count == 0))
+            {
+
+            }
+
             // We want to merge the segment data with the 'out of line' defaults and constraints.
             //
             // This means that for parameters that have 'out of line' defaults we will modify
@@ -298,8 +304,8 @@ namespace Microsoft.AspNetCore.Routing.Patterns
                 rawText,
                 updatedDefaults,
                 updatedConstraints.ToDictionary(kvp => kvp.Key, kvp => (IReadOnlyList<RoutePatternConstraintReference>)kvp.Value.ToArray()),
-                parameters.ToArray(),
-                updatedSegments.ToArray());
+                parameters,
+                updatedSegments);
 
             RoutePatternPathSegment VisitSegment(RoutePatternPathSegment segment)
             {
@@ -310,7 +316,7 @@ namespace Microsoft.AspNetCore.Routing.Patterns
                     updatedParts[i] = VisitPart(part);
                 }
 
-                return SegmentCore(updatedParts);
+                return new RoutePatternPathSegment(updatedParts);
             }
 
             RoutePatternPart VisitPart(RoutePatternPart part)

--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternParser.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternParser.cs
@@ -138,7 +138,7 @@ namespace Microsoft.AspNetCore.Routing.Patterns
 
             if (IsSegmentValid(context, parts))
             {
-                segments.Add(new RoutePatternPathSegment(parts.ToArray()));
+                segments.Add(new RoutePatternPathSegment(parts));
                 return true;
             }
             else

--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternPathSegment.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternPathSegment.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Routing.Patterns
     [DebuggerDisplay("{DebuggerToString()}")]
     public sealed class RoutePatternPathSegment
     {
-        internal RoutePatternPathSegment(RoutePatternPart[] parts)
+        internal RoutePatternPathSegment(IReadOnlyList<RoutePatternPart> parts)
         {
             Parts = parts;
         }


### PR DESCRIPTION
Avoid copying collections when there is already a safe non-parameter copy.