### PR TITLE
Tokenize Less

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/MatcherFindCandidateSetAzureBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/MatcherFindCandidateSetAzureBenchmark.cs
@@ -9,6 +9,10 @@ namespace Microsoft.AspNetCore.Routing.Matching
     // Generated from https://github.com/Azure/azure-rest-api-specs
     public partial class MatcherFindCandidateSetAzureBenchmark : MatcherBenchmarkBase
     {
+        // SegmentCount should be max-segments + 1, but we don't have a good way to compute
+        // it here, so using 16 as a safe guess.
+        private const int SegmentCount = 16;
+
         private const int SampleCount = 100;
 
         private BarebonesMatcher _baseline;
@@ -58,7 +62,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 var httpContext = Requests[sample];
 
                 var path = httpContext.Request.Path.Value;
-                Span<PathSegment> segments = stackalloc PathSegment[FastPathTokenizer.DefaultSegmentCount];
+                Span<PathSegment> segments = stackalloc PathSegment[SegmentCount];
                 var count = FastPathTokenizer.Tokenize(path, segments);
 
                 var candidates = _dfa.FindCandidateSet(httpContext, path, segments.Slice(0, count));

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/MatcherFindCandidateSetGithubBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/MatcherFindCandidateSetGithubBenchmark.cs
@@ -11,6 +11,10 @@ namespace Microsoft.AspNetCore.Routing.Matching
     // Use https://editor2.swagger.io/ to convert from yaml to json-
     public partial class MatcherFindCandidateSetGithubBenchmark : MatcherBenchmarkBase
     {
+        // SegmentCount should be max-segments + 1, but we don't have a good way to compute
+        // it here, so using 16 as a safe guess.
+        private const int SegmentCount = 16;
+
         private BarebonesMatcher _baseline;
         private DfaMatcher _dfa;
 
@@ -50,7 +54,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 var httpContext = Requests[i];
 
                 var path = httpContext.Request.Path.Value;
-                Span<PathSegment> segments = stackalloc PathSegment[FastPathTokenizer.DefaultSegmentCount];
+                Span<PathSegment> segments = stackalloc PathSegment[SegmentCount];
                 var count = FastPathTokenizer.Tokenize(path, segments);
 
                 var candidates = _dfa.FindCandidateSet(httpContext, path, segments.Slice(0, count));

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/MatcherFindCandidateSetSingleEntryBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/MatcherFindCandidateSetSingleEntryBenchmark.cs
@@ -7,8 +7,11 @@ using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Routing.Matching
 {
-    public class MatcheFindCandidateSetSingleEntryBenchmark : MatcherBenchmarkBase
+    public class MatcherFindCandidateSetSingleEntryBenchmark : MatcherBenchmarkBase
     {
+        // SegmentCount should be max-segments + 1
+        private const int SegmentCount = 2;
+
         private TrivialMatcher _baseline;
         private DfaMatcher _dfa;
 
@@ -22,7 +25,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             Requests[0] = new DefaultHttpContext();
             Requests[0].RequestServices = CreateServices();
             Requests[0].Request.Path = "/plaintext";
-            
+
             _baseline = (TrivialMatcher)SetupMatcher(new TrivialMatcherBuilder());
             _dfa = (DfaMatcher)SetupMatcher(CreateDfaMatcherBuilder());
         }
@@ -51,7 +54,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         {
             var httpContext = Requests[0];
             var path = httpContext.Request.Path.Value;
-            Span<PathSegment> segments = stackalloc PathSegment[FastPathTokenizer.DefaultSegmentCount];
+            Span<PathSegment> segments = stackalloc PathSegment[SegmentCount];
             var count = FastPathTokenizer.Tokenize(path, segments);
 
             var candidates = _dfa.FindCandidateSet(httpContext, path, segments.Slice(0, count));

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/MatcherFindCandidateSetSmallEntryCountBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/MatcherFindCandidateSetSmallEntryCountBenchmark.cs
@@ -9,6 +9,9 @@ namespace Microsoft.AspNetCore.Routing.Matching
 {
     public class MatcherFindCandidateSetSmallEntryCountBenchmark : MatcherBenchmarkBase
     {
+        // SegmentCount should be max-segments + 1
+        private const int SegmentCount = 6;
+
         private TrivialMatcher _baseline;
         private DfaMatcher _dfa;
 
@@ -87,7 +90,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var httpContext = Requests[0];
             var path = httpContext.Request.Path.Value;
 
-            Span<PathSegment> segments = stackalloc PathSegment[FastPathTokenizer.DefaultSegmentCount];
+            Span<PathSegment> segments = stackalloc PathSegment[SegmentCount];
             var count = FastPathTokenizer.Tokenize(path, segments);
 
             var candidates = _dfa.FindCandidateSet(httpContext, path, segments.Slice(0, count));

--- a/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcher.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcher.cs
@@ -13,11 +13,13 @@ namespace Microsoft.AspNetCore.Routing.Matching
     {
         private readonly EndpointSelector _selector;
         private readonly DfaState[] _states;
-
-        public DfaMatcher(EndpointSelector selector, DfaState[] states)
+        private readonly int _maxSegmentCount;
+        
+        public DfaMatcher(EndpointSelector selector, DfaState[] states, int maxSegmentCount)
         {
             _selector = selector;
             _states = states;
+            _maxSegmentCount = maxSegmentCount;
         }
 
         public sealed override Task MatchAsync(HttpContext httpContext, IEndpointFeature feature)
@@ -38,7 +40,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var path = httpContext.Request.Path.Value;
 
             // First tokenize the path into series of segments.
-            Span<PathSegment> buffer = stackalloc PathSegment[FastPathTokenizer.DefaultSegmentCount];
+            Span<PathSegment> buffer = stackalloc PathSegment[_maxSegmentCount];
             var count = FastPathTokenizer.Tokenize(path, buffer);
             var segments = buffer.Slice(0, count);
 

--- a/src/Microsoft.AspNetCore.Routing/Matching/DfaNode.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/DfaNode.cs
@@ -22,7 +22,9 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
         // The depth of the node. The depth indicates the number of segments
         // that must be processed to arrive at this node.
-        public int Depth { get; set; }
+        //
+        // This value is not computed for Policy nodes and will be set to -1.
+        public int PathDepth { get; set; } = -1;
 
         // Just for diagnostics and debugging
         public string Label { get; set; }
@@ -71,7 +73,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var builder = new StringBuilder();
             builder.Append(Label);
             builder.Append(" d:");
-            builder.Append(Depth);
+            builder.Append(PathDepth);
             builder.Append(" m:");
             builder.Append(Matches.Count);
             builder.Append(" c: ");

--- a/src/Microsoft.AspNetCore.Routing/Matching/FastPathTokenizer.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/FastPathTokenizer.cs
@@ -9,16 +9,6 @@ namespace Microsoft.AspNetCore.Routing.Matching
     // to PathTokenizer.
     internal static class FastPathTokenizer
     {
-        // The default limit for the number of segments we tokenize.
-        //
-        // Historically the limit on the number of segments routing supports is 28.
-        // RoutePrecedence computes precedence based on a decimal, which supports 28
-        // or 29 digits.
-        //
-        // So setting this limit to 32 should work pretty well. We also expect the tokenizer
-        // to be used with stackalloc, so we want a small number.
-        public const int DefaultSegmentCount = 32;
-
         // This section tokenizes the path by marking the sequence of slashes, and their
         // and the length of the text between them.
         //


### PR DESCRIPTION
This change reduces the amount of buffer space we have to stackalloc, by basing the size on the complexity of the DFA graph. This means for a techempower plaintext scenario, we need space for 2 segments, instead of 32. 

This should dramatically decrease the overhead associated with the zero-intialization of this buffer in all cases, but will have the most effect on low overhead tests like techempower plaintext.

**Before**

|           Method |       Mean |     Error |    StdDev |        Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
|----------------- |-----------:|----------:|----------:|------------:|-------:|---------:|-------:|----------:|
|         Baseline |   139.9 ns |  2.728 ns |  2.801 ns | 7,149,030.5 |   1.00 |     0.00 | 0.0005 |      40 B |
|              Dfa |   255.4 ns |  4.063 ns |  3.393 ns | 3,914,758.0 |   1.83 |     0.04 | 0.0014 |     168 B |
| LegacyTreeRouter | 1,622.2 ns | 24.161 ns | 21.418 ns |   616,453.8 |  11.60 |     0.27 | 0.0038 |     480 B |
|     LegacyRouter | 1,215.8 ns | 13.214 ns | 11.714 ns |   822,470.5 |   8.70 |     0.19 | 0.0038 |     344 B |

**After**

|           Method |       Mean |     Error |    StdDev |        Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
|----------------- |-----------:|----------:|----------:|------------:|-------:|---------:|-------:|----------:|
|         Baseline |   143.7 ns |  1.317 ns |  1.100 ns | 6,958,574.2 |   1.00 |     0.00 | 0.0002 |      40 B |
|              Dfa |   237.0 ns |  3.874 ns |  3.435 ns | 4,218,553.8 |   1.65 |     0.03 | 0.0014 |     168 B |
| LegacyTreeRouter | 1,708.0 ns | 15.888 ns | 14.862 ns |   585,475.2 |  11.89 |     0.13 | 0.0057 |     480 B |
|     LegacyRouter | 1,056.5 ns | 20.943 ns | 17.489 ns |   946,490.6 |   7.35 |     0.13 | 0.0038 |     344 B |
