### PR TITLE
Performance for EndpointMetadataCollection

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/EndpointMetadataCollectionBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/EndpointMetadataCollectionBenchmark.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Routing
+{
+    public class EndpointMetadataCollectionBenchmark
+    {
+        private object[] _items;
+        private EndpointMetadataCollection _collection;
+
+        [Params(3, 10, 25)]
+        public int Count { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var seeds = new Type[]
+            {
+                typeof(Metadata1),
+                typeof(Metadata2),
+                typeof(Metadata3),
+                typeof(Metadata4),
+                typeof(Metadata5),
+                typeof(Metadata6),
+                typeof(Metadata7),
+                typeof(Metadata8),
+                typeof(Metadata9),
+            };
+
+            _items = new object[Count];
+            for (var i = 0; i < _items.Length; i++)
+            {
+                _items[i] = seeds[i % seeds.Length];
+            }
+
+            _collection = new EndpointMetadataCollection(_items);
+        }
+
+        // This is a synthetic baseline that visits each item and does an as-cast.
+        [Benchmark(Baseline = true, OperationsPerInvoke = 5)]
+        public void Baseline()
+        {
+            var items = _items;
+            for (var i = items.Length - 1; i >= 0; i--)
+            {
+                GC.KeepAlive(_items[i] as IMetadata1);
+            }
+
+            for (var i = items.Length - 1; i >= 0; i--)
+            {
+                GC.KeepAlive(_items[i] as IMetadata2);
+            }
+
+            for (var i = items.Length - 1; i >= 0; i--)
+            {
+                GC.KeepAlive(_items[i] as IMetadata3);
+            }
+
+            for (var i = items.Length - 1; i >= 0; i--)
+            {
+                GC.KeepAlive(_items[i] as IMetadata4);
+            }
+
+            for (var i = items.Length - 1; i >= 0; i--)
+            {
+                GC.KeepAlive(_items[i] as IMetadata5);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = 5)]
+        public void GetMetadata()
+        {
+            GC.KeepAlive(_collection.GetMetadata<IMetadata1>());
+            GC.KeepAlive(_collection.GetMetadata<IMetadata2>());
+            GC.KeepAlive(_collection.GetMetadata<IMetadata3>());
+            GC.KeepAlive(_collection.GetMetadata<IMetadata4>());
+            GC.KeepAlive(_collection.GetMetadata<IMetadata5>());
+        }
+
+        [Benchmark(OperationsPerInvoke = 5)]
+        public void GetOrderedMetadata()
+        {
+            foreach (var item in _collection.GetOrderedMetadata<IMetadata1>())
+            {
+                GC.KeepAlive(item);
+            }
+
+            foreach (var item in _collection.GetOrderedMetadata<IMetadata2>())
+            {
+                GC.KeepAlive(item);
+            }
+
+            foreach (var item in _collection.GetOrderedMetadata<IMetadata3>())
+            {
+                GC.KeepAlive(item);
+            }
+
+            foreach (var item in _collection.GetOrderedMetadata<IMetadata4>())
+            {
+                GC.KeepAlive(item);
+            }
+
+            foreach (var item in _collection.GetOrderedMetadata<IMetadata5>())
+            {
+                GC.KeepAlive(item);
+            }
+        }
+
+        private interface IMetadata1 { }
+        private interface IMetadata2 { }
+        private interface IMetadata3 { }
+        private interface IMetadata4 { }
+        private interface IMetadata5 { }
+        private class Metadata1 : IMetadata1 { }
+        private class Metadata2 : IMetadata2 { }
+        private class Metadata3 : IMetadata3 { }
+        private class Metadata4 : IMetadata4 { }
+        private class Metadata5 : IMetadata5 { }
+        private class Metadata6 : IMetadata1, IMetadata2 { }
+        private class Metadata7 : IMetadata2, IMetadata3 { }
+        private class Metadata8 : IMetadata4, IMetadata5 { }
+        private class Metadata9 : IMetadata1, IMetadata2 { }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing.Abstractions/EndpointMetadataCollection.cs
+++ b/src/Microsoft.AspNetCore.Routing.Abstractions/EndpointMetadataCollection.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Routing
 {
@@ -24,6 +26,7 @@ namespace Microsoft.AspNetCore.Routing
         public static readonly EndpointMetadataCollection Empty = new EndpointMetadataCollection(Array.Empty<object>());
 
         private readonly object[] _items;
+        private readonly ConcurrentDictionary<Type, object[]> _cache;
 
         /// <summary>
         /// Creates a new <see cref="EndpointMetadataCollection"/>.
@@ -37,6 +40,7 @@ namespace Microsoft.AspNetCore.Routing
             }
 
             _items = items.ToArray();
+            _cache = new ConcurrentDictionary<Type, object[]>();
         }
 
         /// <summary>
@@ -67,18 +71,23 @@ namespace Microsoft.AspNetCore.Routing
         /// <returns>
         /// The most significant metadata of type <typeparamref name="T"/> or <c>null</c>.
         /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T GetMetadata<T>() where T : class
         {
-            for (var i = _items.Length - 1; i >= 0; i--)
+            if (_cache.TryGetValue(typeof(T), out var result))
             {
-                var item = _items[i] as T;
-                if (item != null)
-                {
-                    return item;
-                }
+                var length = result.Length;
+                return length > 0 ? (T)result[length - 1] : default;
             }
 
-            return default;
+            return GetMetadataSlow<T>();
+        }
+
+        private T GetMetadataSlow<T>() where T : class
+        {
+            var array = GetOrderedMetadataSlow<T>();
+            var length = array.Length;
+            return length > 0 ? array[length - 1] : default;
         }
 
         /// <summary>
@@ -87,16 +96,32 @@ namespace Microsoft.AspNetCore.Routing
         /// </summary>
         /// <typeparam name="T">The type of metadata.</typeparam>
         /// <returns>A sequence of metadata items of <typeparamref name="T"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IEnumerable<T> GetOrderedMetadata<T>() where T : class
         {
+            if (_cache.TryGetValue(typeof(T), out var result))
+            {
+                return (T[])result;
+            }
+
+            return GetOrderedMetadataSlow<T>();
+        }
+
+        private T[] GetOrderedMetadataSlow<T>() where T : class
+        {
+            var items = new List<T>();
             for (var i = 0; i < _items.Length; i++)
             {
                 var item = _items[i] as T;
                 if (item != null)
                 {
-                    yield return item;
+                    items.Add(item);
                 }
             }
+
+            var array = items.ToArray();
+            _cache.TryAdd(typeof(T), array);
+            return array;
         }
 
         /// <summary>

--- a/test/Microsoft.AspNetCore.Mvc.Routing.Abstractions.Tests/EndpointMetadataCollectionTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Routing.Abstractions.Tests/EndpointMetadataCollectionTests.cs
@@ -44,5 +44,98 @@ namespace Microsoft.AspNetCore.Routing
                 value => Assert.Equal(2, value),
                 value => Assert.Equal(3, value));
         }
+
+        [Fact]
+        public void GetMetadata_Match_ReturnsLastMatchingEntry()
+        {
+            // Arrange
+            var items = new object[]
+            {
+                new Metadata1(),
+                new Metadata2(),
+                new Metadata3(),
+            };
+
+            var metadata = new EndpointMetadataCollection(items);
+
+            // Act
+            var result = metadata.GetMetadata<IMetadata5>();
+
+            // Assert
+            Assert.Same(items[1], result);
+        }
+
+        [Fact]
+        public void GetMetadata_NoMatch_ReturnsNull()
+        {
+            // Arrange
+            var items = new object[]
+            {
+                new Metadata3(),
+                new Metadata3(),
+                new Metadata3(),
+            };
+
+            var metadata = new EndpointMetadataCollection(items);
+
+            // Act
+            var result = metadata.GetMetadata<IMetadata5>();
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetOrderedMetadata_Match_ReturnsItemsInAscendingOrder()
+        {
+            // Arrange
+            var items = new object[]
+            {
+                new Metadata1(),
+                new Metadata2(),
+                new Metadata3(),
+            };
+
+            var metadata = new EndpointMetadataCollection(items);
+
+            // Act
+            var result = metadata.GetOrderedMetadata<IMetadata5>();
+
+            // Assert
+            Assert.Collection(
+                result,
+                i => Assert.Same(items[0], i),
+                i => Assert.Same(items[1], i));
+        }
+
+        [Fact]
+        public void GetOrderedMetadata_NoMatch_ReturnsEmpty()
+        {
+            // Arrange
+            var items = new object[]
+            {
+                new Metadata3(),
+                new Metadata3(),
+                new Metadata3(),
+            };
+
+            var metadata = new EndpointMetadataCollection(items);
+
+            // Act
+            var result = metadata.GetOrderedMetadata<IMetadata5>();
+
+            // Assert
+            Assert.Empty(result);
+        }
+
+        private interface IMetadata1 { }
+        private interface IMetadata2 { }
+        private interface IMetadata3 { }
+        private interface IMetadata4 { }
+        private interface IMetadata5 { }
+        private class Metadata1 : IMetadata1, IMetadata4, IMetadata5 { }
+        private class Metadata2 : IMetadata2, IMetadata5 { }
+        private class Metadata3 : IMetadata3 { }
+
     }
 }


### PR DESCRIPTION
#TLDR

The baseline for these tests is the naive implementation (looping with an as-cast). Given that we typically are working with a generic type parameter and that type will be an interface, this is one of the worst cases for casts.

Using a dictionary-based cache is a better option at a really low threshold (4-5 items). I don't feel like it's worth optimizing for the cases where the item collection is really really small, but we could do that in the future if it proves necessary. You'll see that the perf of the dictionary-based implementation is still pretty close for N=3

# Results

|             Method | Count |      Mean |     Error |    StdDev |    Median |         Op/s | Scaled | ScaledSD | Allocated |
|------------------- |------ |----------:|----------:|----------:|----------:|-------------:|-------:|---------:|----------:|
|           **Baseline** |     **3** |  **27.93 ns** | **0.2281 ns** | **0.2133 ns** |  **27.85 ns** | **35,799,096.6** |   **1.00** |     **0.00** |       **0 B** |
|        GetMetadata |     3 |  36.63 ns | 0.7390 ns | 1.5262 ns |  35.66 ns | 27,302,140.5 |   1.31 |     0.05 |       0 B |
| GetOrderedMetadata |     3 |  57.53 ns | 0.0701 ns | 0.0621 ns |  57.52 ns | 17,383,720.3 |   2.06 |     0.02 |       0 B |
|                    |       |           |           |           |           |              |        |          |           |
|           **Baseline** |    **10** |  **85.18 ns** | **2.0738 ns** | **1.7317 ns** |  **84.56 ns** | **11,740,338.5** |   **1.00** |     **0.00** |       **0 B** |
|        GetMetadata |    10 |  36.69 ns | 0.8027 ns | 1.7279 ns |  35.81 ns | 27,257,759.2 |   0.43 |     0.02 |       0 B |
| GetOrderedMetadata |    10 |  58.89 ns | 1.1702 ns | 2.4168 ns |  57.47 ns | 16,980,163.1 |   0.69 |     0.03 |       0 B |
|                    |       |           |           |           |           |              |        |          |           |
|           **Baseline** |    **25** | **208.92 ns** | **0.6678 ns** | **0.5214 ns** | **208.77 ns** |  **4,786,459.7** |   **1.00** |     **0.00** |       **0 B** |
|        GetMetadata |    25 |  36.52 ns | 0.6842 ns | 0.5713 ns |  36.31 ns | 27,379,923.1 |   0.17 |     0.00 |       0 B |
| GetOrderedMetadata |    25 |  59.58 ns | 1.1892 ns | 2.5852 ns |  57.90 ns | 16,784,812.3 |   0.29 |     0.01 |       0 B |