### PR TITLE
Support policy arguments and resolving services by constructors 

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Microsoft.AspNetCore.Routing.Performance.csproj
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Microsoft.AspNetCore.Routing.Performance.csproj
@@ -36,6 +36,7 @@
     <Compile Include="..\..\test\Microsoft.AspNetCore.Routing.Tests\Matching\TreeRouterMatcherBuilder.cs">
       <Link>Matching\TreeRouterMatcherBuilder.cs</Link>
     </Compile>
+    <Compile Include="..\..\test\Microsoft.AspNetCore.Routing.Tests\TestObjects\TestServiceProvider.cs" Link="Matching\TestServiceProvider.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.AspNetCore.Routing/Constraints/BoolRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/BoolRouteConstraint.cs
@@ -20,16 +20,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/CompositeRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/CompositeRouteConstraint.cs
@@ -39,16 +39,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/DateTimeRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/DateTimeRouteConstraint.cs
@@ -26,16 +26,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/DecimalRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/DecimalRouteConstraint.cs
@@ -20,16 +20,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/DoubleRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/DoubleRouteConstraint.cs
@@ -20,16 +20,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/FloatRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/FloatRouteConstraint.cs
@@ -20,16 +20,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/GuidRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/GuidRouteConstraint.cs
@@ -22,16 +22,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/HttpMethodRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/HttpMethodRouteConstraint.cs
@@ -41,16 +41,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));
@@ -64,6 +54,12 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             switch (routeDirection)
             {
                 case RouteDirection.IncomingRequest:
+                    // Only required for constraining incoming requests
+                    if (httpContext == null)
+                    {
+                        throw new ArgumentNullException(nameof(httpContext));
+                    }
+
                     return AllowedMethods.Contains(httpContext.Request.Method, StringComparer.OrdinalIgnoreCase);
 
                 case RouteDirection.UrlGeneration:

--- a/src/Microsoft.AspNetCore.Routing/Constraints/IntRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/IntRouteConstraint.cs
@@ -20,16 +20,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/LengthRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/LengthRouteConstraint.cs
@@ -77,16 +77,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/LongRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/LongRouteConstraint.cs
@@ -20,16 +20,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/MaxLengthRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/MaxLengthRouteConstraint.cs
@@ -40,16 +40,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/MaxRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/MaxRouteConstraint.cs
@@ -34,16 +34,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/MinLengthRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/MinLengthRouteConstraint.cs
@@ -40,16 +40,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/MinRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/MinRouteConstraint.cs
@@ -34,16 +34,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/OptionalRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/OptionalRouteConstraint.cs
@@ -30,16 +30,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/RangeRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/RangeRouteConstraint.cs
@@ -48,16 +48,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/RegexRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/RegexRouteConstraint.cs
@@ -44,16 +44,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/RequiredRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/RequiredRouteConstraint.cs
@@ -24,16 +24,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
             RouteValueDictionary values,
             RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/Constraints/StringRouteConstraint.cs
+++ b/src/Microsoft.AspNetCore.Routing/Constraints/StringRouteConstraint.cs
@@ -31,16 +31,6 @@ namespace Microsoft.AspNetCore.Routing.Constraints
         /// <inheritdoc />
         public bool Match(HttpContext httpContext, IRouter route, string routeKey, RouteValueDictionary values, RouteDirection routeDirection)
         {
-            if (httpContext == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            if (route == null)
-            {
-                throw new ArgumentNullException(nameof(route));
-            }
-
             if (routeKey == null)
             {
                 throw new ArgumentNullException(nameof(routeKey));

--- a/src/Microsoft.AspNetCore.Routing/DefaultInlineConstraintResolver.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultInlineConstraintResolver.cs
@@ -24,13 +24,19 @@ namespace Microsoft.AspNetCore.Routing
         /// <param name="routeOptions">
         /// Accessor for <see cref="RouteOptions"/> containing the constraints of interest.
         /// </param>
+        [Obsolete("This constructor is obsolete. Use DefaultInlineConstraintResolver.ctor(IOptions<RouteOptions>, IServiceProvider) instead.")]
         public DefaultInlineConstraintResolver(IOptions<RouteOptions> routeOptions)
-            : this(routeOptions, null)
         {
+            _inlineConstraintMap = routeOptions.Value.ConstraintMap;
         }
 
         public DefaultInlineConstraintResolver(IOptions<RouteOptions> routeOptions, IServiceProvider serviceProvider)
         {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
             _inlineConstraintMap = routeOptions.Value.ConstraintMap;
             _serviceProvider = serviceProvider;
         }

--- a/src/Microsoft.AspNetCore.Routing/DefaultInlineConstraintResolver.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultInlineConstraintResolver.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Reflection;
+using Microsoft.AspNetCore.Routing.Internal;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Routing
@@ -52,139 +50,7 @@ namespace Microsoft.AspNetCore.Routing
                 throw new ArgumentNullException(nameof(inlineConstraint));
             }
 
-            string constraintKey;
-            string argumentString;
-            var indexOfFirstOpenParens = inlineConstraint.IndexOf('(');
-            if (indexOfFirstOpenParens >= 0 && inlineConstraint.EndsWith(")", StringComparison.Ordinal))
-            {
-                constraintKey = inlineConstraint.Substring(0, indexOfFirstOpenParens);
-                argumentString = inlineConstraint.Substring(indexOfFirstOpenParens + 1,
-                                                            inlineConstraint.Length - indexOfFirstOpenParens - 2);
-            }
-            else
-            {
-                constraintKey = inlineConstraint;
-                argumentString = null;
-            }
-
-            Type constraintType;
-            if (!_inlineConstraintMap.TryGetValue(constraintKey, out constraintType))
-            {
-                // Cannot resolve the constraint key
-                return null;
-            }
-
-            if (!typeof(IRouteConstraint).GetTypeInfo().IsAssignableFrom(constraintType.GetTypeInfo()))
-            {
-                throw new RouteCreationException(
-                            Resources.FormatDefaultInlineConstraintResolver_TypeNotConstraint(
-                                                        constraintType, constraintKey, typeof(IRouteConstraint).Name));
-            }
-
-            try
-            {
-                return CreateConstraint(constraintType, argumentString);
-            }
-            catch (RouteCreationException)
-            {
-                throw;
-            }
-            catch (Exception exception)
-            {
-                throw new RouteCreationException(
-                    $"An error occurred while trying to create an instance of route constraint '{constraintType.FullName}'.",
-                    exception);
-            }
-        }
-
-        internal IRouteConstraint CreateConstraint(Type constraintType, string argumentString)
-        {
-            // No arguments - call the default constructor
-            if (argumentString == null)
-            {
-                return (IRouteConstraint)Activator.CreateInstance(constraintType);
-            }
-
-            var constraintTypeInfo = constraintType.GetTypeInfo();
-            ConstructorInfo activationConstructor = null;
-            object[] parameters = null;
-            var constructors = constraintTypeInfo.DeclaredConstructors.ToArray();
-
-            // If there is only one constructor and it has a single parameter, pass the argument string directly
-            // This is necessary for the Regex RouteConstraint to ensure that patterns are not split on commas.
-            if (constructors.Length == 1 && GetNonConvertableParameterTypeCount(constructors[0].GetParameters()) == 1)
-            {
-                activationConstructor = constructors[0];
-                parameters = ConvertArguments(activationConstructor.GetParameters(), new string[] { argumentString });
-            }
-            else
-            {
-                var arguments = argumentString.Split(',').Select(argument => argument.Trim()).ToArray();
-
-                var matchingConstructors = constructors.Where(ci => GetNonConvertableParameterTypeCount(ci.GetParameters()) == arguments.Length)
-                                                       .ToArray();
-                var constructorMatches = matchingConstructors.Length;
-
-                if (constructorMatches == 0)
-                {
-                    throw new RouteCreationException(
-                                Resources.FormatDefaultInlineConstraintResolver_CouldNotFindCtor(
-                                                       constraintTypeInfo.Name, arguments.Length));
-                }
-                else if (constructorMatches == 1)
-                {
-                    activationConstructor = matchingConstructors[0];
-                    parameters = ConvertArguments(activationConstructor.GetParameters(), arguments);
-                }
-                else
-                {
-                    throw new RouteCreationException(
-                                Resources.FormatDefaultInlineConstraintResolver_AmbiguousCtors(
-                                                       constraintTypeInfo.Name, arguments.Length));
-                }
-            }
-
-            return (IRouteConstraint)activationConstructor.Invoke(parameters);
-        }
-
-        private int GetNonConvertableParameterTypeCount(ParameterInfo[] parameters)
-        {
-            if (_serviceProvider == null)
-            {
-                return parameters.Length;
-            }
-
-            var count = 0;
-            for (int i = 0; i < parameters.Length; i++)
-            {
-                if (parameters[i].ParameterType.IsAssignableFrom(typeof(IConvertible)))
-                {
-                    count++;
-                }
-            }
-
-            return count;
-        }
-
-        private object[] ConvertArguments(ParameterInfo[] parameterInfos, string[] arguments)
-        {
-            var parameters = new object[parameterInfos.Length];
-            for (var i = 0; i < parameterInfos.Length; i++)
-            {
-                var parameter = parameterInfos[i];
-                var parameterType = parameter.ParameterType;
-
-                if (_serviceProvider != null && !parameterType.IsAssignableFrom(typeof(IConvertible)))
-                {
-                    parameters[i] = _serviceProvider.GetService(parameterType);
-                }
-                else
-                {
-                    parameters[i] = Convert.ChangeType(arguments[i], parameterType, CultureInfo.InvariantCulture);
-                }
-            }
-
-            return parameters;
+            return ParameterPolicyActivator.ResolveParameterPolicy<IRouteConstraint>(_inlineConstraintMap, _serviceProvider, inlineConstraint, out _);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Routing/DefaultParameterPolicyFactory.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultParameterPolicyFactory.cs
@@ -3,8 +3,8 @@
 
 using System;
 using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.AspNetCore.Routing.Internal;
 using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Routing
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Routing
 
             if (parameterPolicy is IRouteConstraint routeConstraint)
             {
-                return InitializeRouteConstraint(parameter?.IsOptional ?? false, routeConstraint, argument: null);
+                return InitializeRouteConstraint(parameter?.IsOptional ?? false, routeConstraint);
             }
 
             return parameterPolicy;
@@ -44,47 +44,19 @@ namespace Microsoft.AspNetCore.Routing
                 throw new ArgumentNullException(nameof(inlineText));
             }
 
-            // Example:
-            // {productId:regex(\d+)}
-            //
-            // ParameterName: productId
-            // value: regex(\d+)
-            // name: regex
-            // argument: \d+
-            (var name, var argument) = Parse(inlineText);
+            var parameterPolicy = ParameterPolicyActivator.ResolveParameterPolicy(_options.ConstraintMap, _serviceProvider, inlineText);
 
-            if (!_options.ConstraintMap.TryGetValue(name, out var type))
+            if (parameterPolicy is IRouteConstraint constraint)
             {
-                throw new InvalidOperationException(Resources.FormatRoutePattern_ConstraintReferenceNotFound(
-                    name,
-                    typeof(RouteOptions),
-                    nameof(RouteOptions.ConstraintMap)));
+                return InitializeRouteConstraint(parameter?.IsOptional ?? false, constraint);
             }
 
-            if (typeof(IRouteConstraint).IsAssignableFrom(type))
-            {
-                var constraint = DefaultInlineConstraintResolver.CreateConstraint(type, argument);
-                return InitializeRouteConstraint(parameter?.IsOptional ?? false, constraint, argument);
-            }
-
-            if (typeof(IParameterPolicy).IsAssignableFrom(type))
-            {
-                var parameterPolicy = (IParameterPolicy)_serviceProvider.GetRequiredService(type);
-                return parameterPolicy;
-            }
-
-            var message = Resources.FormatRoutePattern_InvalidStringConstraintReference(
-                type,
-                name,
-                typeof(IRouteConstraint),
-                typeof(IParameterPolicy));
-            throw new InvalidOperationException(message);
+            return parameterPolicy;
         }
 
         private IParameterPolicy InitializeRouteConstraint(
             bool optional,
-            IRouteConstraint routeConstraint,
-            string argument)
+            IRouteConstraint routeConstraint)
         {
             if (optional)
             {
@@ -92,26 +64,6 @@ namespace Microsoft.AspNetCore.Routing
             }
 
             return routeConstraint;
-        }
-
-        private (string name, string argument) Parse(string text)
-        {
-            string name;
-            string argument;
-            var indexOfFirstOpenParens = text.IndexOf('(');
-            if (indexOfFirstOpenParens >= 0 && text.EndsWith(")", StringComparison.Ordinal))
-            {
-                name = text.Substring(0, indexOfFirstOpenParens);
-                argument = text.Substring(
-                    indexOfFirstOpenParens + 1,
-                    text.Length - indexOfFirstOpenParens - 2);
-            }
-            else
-            {
-                name = text;
-                argument = null;
-            }
-            return (name, argument);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Routing/DefaultParameterPolicyFactory.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultParameterPolicyFactory.cs
@@ -44,7 +44,14 @@ namespace Microsoft.AspNetCore.Routing
                 throw new ArgumentNullException(nameof(inlineText));
             }
 
-            var parameterPolicy = ParameterPolicyActivator.ResolveParameterPolicy(_options.ConstraintMap, _serviceProvider, inlineText);
+            var parameterPolicy = ParameterPolicyActivator.ResolveParameterPolicy<IParameterPolicy>(_options.ConstraintMap, _serviceProvider, inlineText, out var parameterPolicyKey);
+            if (parameterPolicy == null)
+            {
+                throw new InvalidOperationException(Resources.FormatRoutePattern_ConstraintReferenceNotFound(
+                        parameterPolicyKey,
+                        typeof(RouteOptions),
+                        nameof(RouteOptions.ConstraintMap)));
+            }
 
             if (parameterPolicy is IRouteConstraint constraint)
             {

--- a/src/Microsoft.AspNetCore.Routing/Internal/ParameterPolicyActivator.cs
+++ b/src/Microsoft.AspNetCore.Routing/Internal/ParameterPolicyActivator.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Routing.Internal
+{
+    internal static class ParameterPolicyActivator
+    {
+        public static IParameterPolicy ResolveParameterPolicy(IDictionary<string, Type> inlineParameterPolicyMap, IServiceProvider serviceProvider, string inlineParameterPolicy)
+        {
+            if (inlineParameterPolicy == null)
+            {
+                throw new ArgumentNullException(nameof(inlineParameterPolicy));
+            }
+
+            string parameterPolicyKey;
+            string argumentString;
+            var indexOfFirstOpenParens = inlineParameterPolicy.IndexOf('(');
+            if (indexOfFirstOpenParens >= 0 && inlineParameterPolicy.EndsWith(")", StringComparison.Ordinal))
+            {
+                parameterPolicyKey = inlineParameterPolicy.Substring(0, indexOfFirstOpenParens);
+                argumentString = inlineParameterPolicy.Substring(
+                    indexOfFirstOpenParens + 1,
+                    inlineParameterPolicy.Length - indexOfFirstOpenParens - 2);
+            }
+            else
+            {
+                parameterPolicyKey = inlineParameterPolicy;
+                argumentString = null;
+            }
+
+            if (!inlineParameterPolicyMap.TryGetValue(parameterPolicyKey, out var parameterPolicyType))
+            {
+                throw new InvalidOperationException(Resources.FormatRoutePattern_ConstraintReferenceNotFound(
+                    parameterPolicyKey,
+                    typeof(RouteOptions),
+                    nameof(RouteOptions.ConstraintMap)));
+            }
+
+            if (!typeof(IParameterPolicy).IsAssignableFrom(parameterPolicyType))
+            {
+                throw new RouteCreationException(
+                            Resources.FormatDefaultInlineConstraintResolver_TypeNotConstraint(
+                                                        parameterPolicyType, parameterPolicyKey, typeof(IParameterPolicy).Name));
+            }
+
+            try
+            {
+                return CreateParameterPolicy(serviceProvider, parameterPolicyType, argumentString);
+            }
+            catch (RouteCreationException)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                throw new RouteCreationException(
+                    $"An error occurred while trying to create an instance of '{parameterPolicyType.FullName}'.",
+                    exception);
+            }
+        }
+
+        internal static IParameterPolicy CreateParameterPolicy(IServiceProvider serviceProvider, Type constraintType, string argumentString)
+        {
+            // No arguments - call the default constructor
+            if (argumentString == null)
+            {
+                return (IParameterPolicy)Activator.CreateInstance(constraintType);
+            }
+
+            var constraintTypeInfo = constraintType.GetTypeInfo();
+            ConstructorInfo activationConstructor = null;
+            object[] parameters = null;
+            var constructors = constraintTypeInfo.DeclaredConstructors.ToArray();
+
+            // If there is only one constructor and it has a single parameter, pass the argument string directly
+            // This is necessary for the Regex RouteConstraint to ensure that patterns are not split on commas.
+            if (constructors.Length == 1 && GetNonConvertableParameterTypeCount(serviceProvider, constructors[0].GetParameters()) == 1)
+            {
+                activationConstructor = constructors[0];
+                parameters = ConvertArguments(serviceProvider, activationConstructor.GetParameters(), new string[] { argumentString });
+            }
+            else
+            {
+                var arguments = argumentString.Split(',').Select(argument => argument.Trim()).ToArray();
+
+                var matchingConstructors = constructors.Where(ci => GetNonConvertableParameterTypeCount(serviceProvider, ci.GetParameters()) == arguments.Length)
+                                                       .ToArray();
+                var constructorMatches = matchingConstructors.Length;
+
+                if (constructorMatches == 0)
+                {
+                    throw new RouteCreationException(
+                                Resources.FormatDefaultInlineConstraintResolver_CouldNotFindCtor(
+                                                       constraintTypeInfo.Name, arguments.Length));
+                }
+                else if (constructorMatches == 1)
+                {
+                    activationConstructor = matchingConstructors[0];
+                    parameters = ConvertArguments(serviceProvider, activationConstructor.GetParameters(), arguments);
+                }
+                else
+                {
+                    throw new RouteCreationException(
+                                Resources.FormatDefaultInlineConstraintResolver_AmbiguousCtors(
+                                                       constraintTypeInfo.Name, arguments.Length));
+                }
+            }
+
+            return (IParameterPolicy)activationConstructor.Invoke(parameters);
+        }
+
+        private static int GetNonConvertableParameterTypeCount(IServiceProvider serviceProvider, ParameterInfo[] parameters)
+        {
+            if (serviceProvider == null)
+            {
+                return parameters.Length;
+            }
+
+            var count = 0;
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (typeof(IConvertible).IsAssignableFrom(parameters[i].ParameterType))
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static object[] ConvertArguments(IServiceProvider serviceProvider, ParameterInfo[] parameterInfos, string[] arguments)
+        {
+            var parameters = new object[parameterInfos.Length];
+            var argumentPosition = 0;
+            for (var i = 0; i < parameterInfos.Length; i++)
+            {
+                var parameter = parameterInfos[i];
+                var parameterType = parameter.ParameterType;
+
+                if (serviceProvider != null && !typeof(IConvertible).IsAssignableFrom(parameterType))
+                {
+                    parameters[i] = serviceProvider.GetService(parameterType);
+                }
+                else
+                {
+                    parameters[i] = Convert.ChangeType(arguments[argumentPosition], parameterType, CultureInfo.InvariantCulture);
+                    argumentPosition++;
+                }
+            }
+
+            return parameters;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/Internal/ParameterPolicyActivator.cs
+++ b/src/Microsoft.AspNetCore.Routing/Internal/ParameterPolicyActivator.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Routing.Internal
 {
@@ -143,7 +144,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
                 if (serviceProvider != null && !typeof(IConvertible).IsAssignableFrom(parameterType))
                 {
-                    parameters[i] = serviceProvider.GetService(parameterType);
+                    parameters[i] = serviceProvider.GetRequiredService(parameterType);
                 }
                 else
                 {

--- a/test/Microsoft.AspNetCore.Routing.Tests/DefaultInlineConstraintResolverTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/DefaultInlineConstraintResolverTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -324,11 +325,33 @@ namespace Microsoft.AspNetCore.Routing.Tests
                          ex.Message);
         }
 
-        private IInlineConstraintResolver GetInlineConstraintResolver(RouteOptions routeOptions)
+        [Fact]
+        public void ResolveConstraint_HasArguments_NoServiceProvider()
+        {
+            // Arrange
+            var routeOptions = new RouteOptions();
+            var constraintResolver = GetInlineConstraintResolver(routeOptions, hasServiceProvider: false);
+
+            // Act
+            var constraint = constraintResolver.ResolveConstraint("regex(ab,1)");
+
+            // Assert
+            Assert.IsType<RegexInlineRouteConstraint>(constraint);
+        }
+
+        private IInlineConstraintResolver GetInlineConstraintResolver(RouteOptions routeOptions, bool hasServiceProvider = true)
         {
             var optionsAccessor = new Mock<IOptions<RouteOptions>>();
             optionsAccessor.SetupGet(o => o.Value).Returns(routeOptions);
+
+            if (hasServiceProvider)
+            {
+                return new DefaultInlineConstraintResolver(optionsAccessor.Object, new TestServiceProvider());
+            }
+
+#pragma warning disable CS0618 // Type or member is obsolete
             return new DefaultInlineConstraintResolver(optionsAccessor.Object);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         private class MultiConstructorRouteConstraint : IRouteConstraint

--- a/test/Microsoft.AspNetCore.Routing.Tests/InlineRouteParameterParserTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/InlineRouteParameterParserTests.cs
@@ -968,7 +968,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
                                 .Add("test", typeof(TestRouteConstraint)));
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
-            return new DefaultInlineConstraintResolver(accessor);
+            return new DefaultInlineConstraintResolver(accessor, serviceProvider);
         }
 
         private class TestRouteConstraint : IRouteConstraint

--- a/test/Microsoft.AspNetCore.Routing.Tests/Matching/RouteMatcherBuilder.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Matching/RouteMatcherBuilder.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Routing.Matching
@@ -18,7 +19,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
         public RouteMatcherBuilder()
         {
-            _constraintResolver = new DefaultInlineConstraintResolver(Options.Create(new RouteOptions()));
+            _constraintResolver = new DefaultInlineConstraintResolver(Options.Create(new RouteOptions()), new TestServiceProvider());
             _endpoints = new List<RouteEndpoint>();
         }
 

--- a/test/Microsoft.AspNetCore.Routing.Tests/Matching/TreeRouterMatcherBuilder.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Matching/TreeRouterMatcherBuilder.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Internal;
 using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.AspNetCore.Routing.Tree;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.ObjectPool;
@@ -34,7 +35,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var builder = new TreeRouteBuilder(
                 NullLoggerFactory.Instance,
                 new DefaultObjectPool<UriBuildingContext>(new UriBuilderContextPooledObjectPolicy()),
-                new DefaultInlineConstraintResolver(Options.Create(new RouteOptions())));
+                new DefaultInlineConstraintResolver(Options.Create(new RouteOptions()), new TestServiceProvider()));
 
             var selector = new DefaultEndpointSelector(Array.Empty<MatcherPolicy>());
 

--- a/test/Microsoft.AspNetCore.Routing.Tests/RouteConstraintBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/RouteConstraintBuilderTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.AspNetCore.Testing;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -183,7 +184,7 @@ namespace Microsoft.AspNetCore.Routing
                 .SetupGet(o => o.Value)
                 .Returns(new RouteOptions());
 
-            var inlineConstraintResolver = new DefaultInlineConstraintResolver(options.Object);
+            var inlineConstraintResolver = new DefaultInlineConstraintResolver(options.Object, new TestServiceProvider());
             return new RouteConstraintBuilder(inlineConstraintResolver, template);
         }
     }

--- a/test/Microsoft.AspNetCore.Routing.Tests/RouteTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/RouteTest.cs
@@ -1842,7 +1842,7 @@ namespace Microsoft.AspNetCore.Routing
                 .SetupGet(o => o.Value)
                 .Returns(new RouteOptions());
 
-            return new DefaultInlineConstraintResolver(routeOptions.Object);
+            return new DefaultInlineConstraintResolver(routeOptions.Object, new TestServiceProvider());
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
@@ -1293,7 +1293,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var services = new ServiceCollection().AddOptions();
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
-            return new DefaultInlineConstraintResolver(accessor);
+            return new DefaultInlineConstraintResolver(accessor, serviceProvider);
         }
 
         private class PathAndQuery

--- a/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateMatcherTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateMatcherTests.cs
@@ -1136,7 +1136,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
             var services = new ServiceCollection().AddOptions();
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
-            return new DefaultInlineConstraintResolver(accessor);
+            return new DefaultInlineConstraintResolver(accessor, serviceProvider);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Routing.Tests/TemplateParserDefaultValuesTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/TemplateParserDefaultValuesTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
             var services = new ServiceCollection().AddOptions();
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
-            return new DefaultInlineConstraintResolver(accessor);
+            return new DefaultInlineConstraintResolver(accessor, serviceProvider);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouteBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouteBuilderTest.cs
@@ -260,7 +260,7 @@ namespace Microsoft.AspNetCore.Routing.Tree
             var services = new ServiceCollection().AddOptions();
             var serviceProvider = services.BuildServiceProvider();
             var accessor = serviceProvider.GetRequiredService<IOptions<RouteOptions>>();
-            return new DefaultInlineConstraintResolver(accessor);
+            return new DefaultInlineConstraintResolver(accessor, serviceProvider);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouterTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Tree/TreeRouterTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Internal;
 using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.ObjectPool;
@@ -2133,7 +2134,7 @@ namespace Microsoft.AspNetCore.Routing.Tree
             var optionsMock = new Mock<IOptions<RouteOptions>>();
             optionsMock.SetupGet(o => o.Value).Returns(options);
 
-            return new DefaultInlineConstraintResolver(optionsMock.Object);
+            return new DefaultInlineConstraintResolver(optionsMock.Object, new TestServiceProvider());
         }
 
         private static TreeRouteBuilder CreateBuilder()


### PR DESCRIPTION
I looked into `ActivatorUtilities` and it isn't suitable. The way its constructor matching works is it relies on the parameters being the correct type, and then assumes everything else comes from DI. For inline policies, the arguments for a constructor will always be strings, so that won't work.

Meanwhile constraint constructors are matched on the number of parameters, and then args are converted to the correct types.

What I have done is assume that anything that is populated from the inline argument is `IConvertible` (today `Convert.ChangeType` is used in constraint resolver so that is an ok assumption), and everything else is attempted to be resolved from DI.

I want `DefaultInlineConstraintResolver` and `DefaultParameterPolicyFactory` to use the same code internally. Both will be thin wrappers over the same logic, the difference being the constraint resolver will blow up if the resolve type isn't a constraint.

@rynowak Let me know whether you are ok with this approach. After that I will finish cleaning it up.