### PR TITLE
Optimize builder and HTTP policy allocations

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
@@ -343,16 +343,16 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
             if (node.Literals != null)
             {
+                var entries = new (string text, int destination)[node.Literals.Count];
+
+                var index = 0;
                 foreach (var kvp in node.Literals)
                 {
-                    if (kvp.Key == null)
-                    {
-                        continue;
-                    }
-
                     var transition = Transition(kvp.Value);
-                    pathBuilder.AddEntry(kvp.Key, transition);
+                    entries[index++] = (kvp.Key, transition);
                 }
+
+                pathBuilder.AddEntries(entries);
             }
 
             if (node.Parameters != null &&
@@ -388,10 +388,15 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 var policyBuilder = new PolicyJumpTableBuilder(node.NodeBuilder);
                 tableBuilders[currentStateIndex] = (pathBuilder, policyBuilder);
 
+                var entries = new PolicyJumpTableEdge[node.PolicyEdges.Count];
+
+                var index = 0;
                 foreach (var kvp in node.PolicyEdges)
                 {
-                    policyBuilder.AddEntry(kvp.Key, Transition(kvp.Value));
+                    entries[index++] = new PolicyJumpTableEdge(kvp.Key, Transition(kvp.Value));
                 }
+
+                policyBuilder.AddEntries(entries);
             }
 
             return currentStateIndex;

--- a/src/Microsoft.AspNetCore.Routing/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/HttpMethodMatcherPolicy.cs
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             //
             // For now we're just building up the set of keys. We don't add any endpoints
             // to lists now because we don't want ordering problems.
-            var allHttpMethods = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var allHttpMethods = new List<string>();
             var edges = new Dictionary<EdgeKey, List<Endpoint>>();
             for (var i = 0; i < endpoints.Count; i++)
             {
@@ -120,10 +120,15 @@ namespace Microsoft.AspNetCore.Routing.Matching
                     // Also if it's not the *any* method key, then track it.
                     if (!string.Equals(AnyMethod, httpMethod, StringComparison.OrdinalIgnoreCase))
                     {
-                        allHttpMethods.Add(httpMethod);
+                        if (!ContainsHttpMethod(allHttpMethods, httpMethod))
+                        {
+                            allHttpMethods.Add(httpMethod);
+                        }
                     }
                 }
             }
+
+            allHttpMethods.Sort(StringComparer.OrdinalIgnoreCase);
 
             // Now in a second loop, add endpoints to these lists. We've enumerated all of
             // the states, so we want to see which states this endpoint matches.
@@ -185,7 +190,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             if (!edges.TryGetValue(new EdgeKey(AnyMethod, false), out var matches))
             {
                 // Methods sorted for testability.
-                var endpoint = CreateRejectionEndpoint(allHttpMethods.OrderBy(m => m));
+                var endpoint = CreateRejectionEndpoint(allHttpMethods);
                 matches = new List<Endpoint>() { endpoint, };
                 edges[new EdgeKey(AnyMethod, false)] = matches;
             }
@@ -259,6 +264,19 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 },
                 EndpointMetadataCollection.Empty,
                 Http405EndpointDisplayName);
+        }
+
+        public static bool ContainsHttpMethod(List<string> httpMethods, string httpMethod)
+        {
+            for (int i = 0; i < httpMethods.Count; i++)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(httpMethods[i], httpMethod))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private class HttpMethodPolicyJumpTable : PolicyJumpTable

--- a/src/Microsoft.AspNetCore.Routing/Matching/PolicyJumpTableBuilder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/PolicyJumpTableBuilder.cs
@@ -8,20 +8,19 @@ namespace Microsoft.AspNetCore.Routing.Matching
     internal class PolicyJumpTableBuilder
     {
         private readonly INodeBuilderPolicy _nodeBuilder;
-        private readonly List<PolicyJumpTableEdge> _entries;
+        private PolicyJumpTableEdge[] _entries;
 
         public PolicyJumpTableBuilder(INodeBuilderPolicy nodeBuilder)
         {
             _nodeBuilder = nodeBuilder;
-            _entries = new List<PolicyJumpTableEdge>();
         }
 
         // The destination state for a non-match.
         public int ExitDestination { get; set; } = JumpTableBuilder.InvalidDestination;
 
-        public void AddEntry(object state, int destination)
+        public void AddEntries(PolicyJumpTableEdge[] entries)
         {
-            _entries.Add(new PolicyJumpTableEdge(state, destination));
+            _entries = entries;
         }
 
         public PolicyJumpTable Build()


### PR DESCRIPTION
Before:
```
 Method |     Mean |    Error |   StdDev |  Op/s |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
------- |---------:|---------:|---------:|------:|---------:|---------:|---------:|----------:|
    Dfa | 324.0 ms | 6.375 ms | 14.52 ms | 3.087 | 562.5000 | 500.0000 | 375.0000 | 130.02 MB |
```

After:
```
 Method |     Mean |    Error |   StdDev |  Op/s |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
------- |---------:|---------:|---------:|------:|---------:|---------:|---------:|----------:|
    Dfa | 279.5 ms | 5.582 ms | 7.452 ms | 3.578 | 687.5000 | 500.0000 | 312.5000 | 115.25 MB |
```