### PR TITLE
Add flag for including label with DfaNodes

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Internal/DfaGraphWriter.cs
+++ b/src/Microsoft.AspNetCore.Routing/Internal/DfaGraphWriter.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             // Assign each node a sequential index.
             var visited = new Dictionary<DfaNode, int>();
             
-            var tree = builder.BuildDfaTree();
+            var tree = builder.BuildDfaTree(includeLabel: true);
 
             writer.WriteLine("digraph DFA {");
             tree.Visit(WriteNode);

--- a/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
@@ -273,7 +273,13 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
         public override Matcher Build()
         {
-            var root = BuildDfaTree();
+#if DEBUG
+            var includeLabel = true;
+#else
+            var includeLabel = false;
+#endif
+
+            var root = BuildDfaTree(includeLabel);
 
             // State count is the number of nodes plus an exit state
             var stateCount = 1;

--- a/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             _endpoints.Add(endpoint);
         }
 
-        public DfaNode BuildDfaTree()
+        public DfaNode BuildDfaTree(bool includeLabel = false)
         {
             // We build the tree by doing a BFS over the list of entries. This is important
             // because a 'parameter' node can also traverse the same paths that literal nodes
@@ -67,7 +67,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
             var work = new List<(RouteEndpoint endpoint, List<DfaNode> parents)>(_endpoints.Count);
             List<(RouteEndpoint endpoint, List<DfaNode> parents)> previousWork = null;
 
-            var root = new DfaNode() { PathDepth = 0, Label = "/" };
+            var root = new DfaNode() { PathDepth = 0, Label = includeLabel ? "/" : null };
 
             // To prepare for this we need to compute the max depth, as well as
             // a seed list of items to process (entry, root).
@@ -149,7 +149,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                                 next = new DfaNode()
                                 {
                                     PathDepth = parent.PathDepth + 1,
-                                    Label = parent.Label + literal + "/",
+                                    Label = includeLabel ? parent.Label + literal + "/" : null,
                                 };
                                 parent.AddLiteral(literal, next);
                             }
@@ -180,7 +180,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                                 parent.CatchAll = new DfaNode()
                                 {
                                     PathDepth = parent.PathDepth + 1,
-                                    Label = parent.Label + "{*...}/",
+                                    Label = includeLabel ? parent.Label + "{*...}/" : null,
                                 };
 
                                 // The catchall node just loops.
@@ -197,7 +197,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                                 parent.Parameters = new DfaNode()
                                 {
                                     PathDepth = parent.PathDepth + 1,
-                                    Label = parent.Label + "{...}/",
+                                    Label = includeLabel ? parent.Label + "{...}/" : null,
                                 };
                             }
 
@@ -219,7 +219,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                                 parent.Parameters = new DfaNode()
                                 {
                                     PathDepth = parent.PathDepth + 1,
-                                    Label = parent.Label + "{...}/",
+                                    Label = includeLabel ? parent.Label + "{...}/" : null,
                                 };
                             }
 
@@ -613,7 +613,8 @@ namespace Microsoft.AspNetCore.Routing.Matching
 
                         var next = new DfaNode()
                         {
-                            Label = parent.Label + " " + edge.State.ToString(),
+                            // If parent label is null then labels are not being included
+                            Label = (parent.Label != null) ? parent.Label + " " + edge.State.ToString() : null,
                         };
 
                         if (edge.Endpoints.Count > 0)

--- a/src/Microsoft.AspNetCore.Routing/Matching/HttpMethodMatcherPolicy.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/HttpMethodMatcherPolicy.cs
@@ -195,9 +195,14 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 edges[new EdgeKey(AnyMethod, false)] = matches;
             }
 
-            return edges
-                .Select(kvp => new PolicyNodeEdge(kvp.Key, kvp.Value))
-                .ToArray();
+            var policyNodeEdges = new PolicyNodeEdge[edges.Count];
+            var index = 0;
+            foreach (var kvp in edges)
+            {
+                policyNodeEdges[index++] = new PolicyNodeEdge(kvp.Key, kvp.Value);
+            }
+
+            return policyNodeEdges;
 
             (IReadOnlyList<string> httpMethods, bool acceptCorsPreflight) GetHttpMethods(Endpoint e)
             {


### PR DESCRIPTION
Before:
```
 Method |     Mean |    Error |   StdDev |  Op/s |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
------- |---------:|---------:|---------:|------:|---------:|---------:|---------:|----------:|
    Dfa | 279.5 ms | 5.582 ms | 7.452 ms | 3.578 | 687.5000 | 500.0000 | 312.5000 | 115.25 MB |
```

After:
```
 Method |     Mean |    Error |   StdDev |  Op/s |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
------- |---------:|---------:|---------:|------:|---------:|---------:|---------:|----------:|
    Dfa | 243.7 ms | 4.873 ms | 7.441 ms | 4.103 | 500.0000 | 375.0000 | 250.0000 |  88.25 MB |
```