### PR TITLE
Avoid RoutePattern allocating empty dictionaries

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/RouteEndpointAzureBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/RouteEndpointAzureBenchmark.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.AspNetCore.Routing.Matching
+{
+    public class RouteEndpointAzureBenchmark : MatcherAzureBenchmarkBase
+    {
+        [Benchmark]
+        public void CreateEndpoints()
+        {
+            SetupEndpoints();
+        }
+    }
+}


### PR DESCRIPTION
Eliminates the dictionary allocations from https://github.com/aspnet/Routing/pull/764#issuecomment-418214987

I'm on the fence over whether the extra complexity is worth the savings.