### PR TITLE
Link Generator perf improvements. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ node_modules
 *launchSettings.json
 global.json
 BenchmarkDotNet.Artifacts/
+*.etl.zip

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/LinkGeneration/LinkGenerationGithubBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/LinkGeneration/LinkGenerationGithubBenchmark.cs
@@ -44,6 +44,13 @@ namespace Microsoft.AspNetCore.Routing.LinkGeneration
         }
 
         [Benchmark(Baseline = true)]
+        public void Baseline()
+        {
+            var url = $"/repos/{_lookUpValues["owner"]}/{_lookUpValues["repo"]}/issues/comments/{_lookUpValues["commentId"]}";
+            AssertUrl("/repos/aspnet/routing/issues/comments/20202", url);
+        }
+
+        [Benchmark]
         public void TreeRouter()
         {
             var virtualPathData = _treeRouter.GetVirtualPath(new VirtualPathContext(

--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternMatcher.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternMatcher.cs
@@ -193,10 +193,14 @@ namespace Microsoft.AspNetCore.Routing
             // Copy all remaining default values to the route data
             foreach (var kvp in Defaults)
             {
+#if RVD_TryAdd
+                values.TryAdd(kvp.Key, kvp.Value);
+#else
                 if (!values.ContainsKey(kvp.Key))
                 {
                     values.Add(kvp.Key, kvp.Value);
                 }
+#endif
             }
 
             return true;

--- a/src/Microsoft.AspNetCore.Routing/RouteBase.cs
+++ b/src/Microsoft.AspNetCore.Routing/RouteBase.cs
@@ -208,6 +208,14 @@ namespace Microsoft.AspNetCore.Routing
             {
                 if (parameter.DefaultValue != null)
                 {
+#if RVD_TryAdd
+                    if (!result.TryAdd(parameter.Name, parameter.DefaultValue))
+                    {
+                        throw new InvalidOperationException(
+                          Resources.FormatTemplateRoute_CannotHaveDefaultValueSpecifiedInlineAndExplicitly(
+                              parameter.Name));
+                    }
+#else
                     if (result.ContainsKey(parameter.Name))
                     {
                         throw new InvalidOperationException(
@@ -218,6 +226,7 @@ namespace Microsoft.AspNetCore.Routing
                     {
                         result.Add(parameter.Name, parameter.DefaultValue);
                     }
+#endif
                 }
             }
 

--- a/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
@@ -21,24 +21,26 @@ namespace Microsoft.AspNetCore.Routing
         {
             // Arrange
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
-                "{controller}/{action}/{id}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "In?dex", })) });
+                "Home/Index/{id}",
+                defaults: new { controller = "Home", action = "Index", },
+                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
-                "{controller}/{action}/{id?}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "In?dex", })) });
+                "Home/Index/{id?}",
+                defaults: new { controller = "Home", action = "Index", },
+                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
             // Act
             var path = linkGenerator.GetPathByRouteValues(
                 routeName: null,
-                values: new RouteValueDictionary(new { controller = "Home", action = "In?dex", query = "some?query" }),
+                values: new RouteValueDictionary(new { controller = "Home", action = "Index", query = "some?query" }),
                 new PathString("/Foo/Bar?encodeme?"),
                 new FragmentString("#Fragment?"),
                 new LinkOptions() { AppendTrailingSlash = true, });
 
             // Assert
-            Assert.Equal("/Foo/Bar%3Fencodeme%3F/Home/In%3Fdex/?query=some%3Fquery#Fragment?", path);
+            Assert.Equal("/Foo/Bar%3Fencodeme%3F/Home/Index/?query=some%3Fquery#Fragment?", path);
         }
 
         [Fact]
@@ -46,11 +48,13 @@ namespace Microsoft.AspNetCore.Routing
         {
             // Arrange
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
-                "{controller}/{action}/{id}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "In?dex", })) });
+                "Home/Index/{id}",
+                defaults: new { controller = "Home", action = "Index", },
+                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
-                "{controller}/{action}/{id?}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "In?dex", })) });
+                "Home/Index/{id?}",
+                defaults: new { controller = "Home", action = "Index", },
+                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -61,12 +65,12 @@ namespace Microsoft.AspNetCore.Routing
             var path = linkGenerator.GetPathByRouteValues(
                 httpContext,
                 routeName: null,
-                values: new RouteValueDictionary(new { controller = "Home", action = "In?dex", query = "some?query" }),
+                values: new RouteValueDictionary(new { controller = "Home", action = "Index", query = "some?query" }),
                 new FragmentString("#Fragment?"),
                 new LinkOptions() { AppendTrailingSlash = true, });
 
             // Assert
-            Assert.Equal("/Foo/Bar%3Fencodeme%3F/Home/In%3Fdex/?query=some%3Fquery#Fragment?", path);
+            Assert.Equal("/Foo/Bar%3Fencodeme%3F/Home/Index/?query=some%3Fquery#Fragment?", path);
         }
 
         [Fact]
@@ -74,18 +78,20 @@ namespace Microsoft.AspNetCore.Routing
         {
             // Arrange
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
-                "{controller}/{action}/{id}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "In?dex", })) });
+                "Home/Index/{id}",
+                defaults: new { controller = "Home", action = "Index", },
+                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
-                "{controller}/{action}/{id?}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "In?dex", })) });
+                "Home/Index/{id?}",
+                defaults: new { controller = "Home", action = "Index", },
+                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
             // Act
             var path = linkGenerator.GetUriByRouteValues(
                 routeName: null,
-                values: new RouteValueDictionary(new { controller = "Home", action = "In?dex", query = "some?query" }),
+                values: new RouteValueDictionary(new { controller = "Home", action = "Index", query = "some?query" }),
                 "http",
                 new HostString("example.com"),
                 new PathString("/Foo/Bar?encodeme?"),
@@ -93,7 +99,7 @@ namespace Microsoft.AspNetCore.Routing
                 new LinkOptions() { AppendTrailingSlash = true, });
 
             // Assert
-            Assert.Equal("http://example.com/Foo/Bar%3Fencodeme%3F/Home/In%3Fdex/?query=some%3Fquery#Fragment?", path);
+            Assert.Equal("http://example.com/Foo/Bar%3Fencodeme%3F/Home/Index/?query=some%3Fquery#Fragment?", path);
         }
 
         [Fact]
@@ -101,11 +107,13 @@ namespace Microsoft.AspNetCore.Routing
         {
             // Arrange
             var endpoint1 = EndpointFactory.CreateRouteEndpoint(
-                "{controller}/{action}/{id}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "In?dex", })) });
+                "Home/Index/{id}",
+                defaults: new { controller = "Home", action = "Index", },
+                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
             var endpoint2 = EndpointFactory.CreateRouteEndpoint(
-                "{controller}/{action}/{id?}",
-                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "In?dex", })) });
+                "Home/Index/{id?}",
+                defaults: new { controller = "Home", action = "Index", },
+                metadata: new[] { new RouteValuesAddressMetadata(routeName: null, new RouteValueDictionary(new { controller = "Home", action = "Index", })) });
 
             var linkGenerator = CreateLinkGenerator(endpoint1, endpoint2);
 
@@ -118,12 +126,12 @@ namespace Microsoft.AspNetCore.Routing
             var uri = linkGenerator.GetUriByRouteValues(
                 httpContext,
                 routeName: null,
-                values: new RouteValueDictionary(new { controller = "Home", action = "In?dex", query = "some?query" }),
+                values: new RouteValueDictionary(new { controller = "Home", action = "Index", query = "some?query" }),
                 new FragmentString("#Fragment?"),
                 new LinkOptions() { AppendTrailingSlash = true, });
 
             // Assert
-            Assert.Equal("http://example.com/Foo/Bar%3Fencodeme%3F/Home/In%3Fdex/?query=some%3Fquery#Fragment?", uri);
+            Assert.Equal("http://example.com/Foo/Bar%3Fencodeme%3F/Home/Index/?query=some%3Fquery#Fragment?", uri);
         }
 
         [Fact]

--- a/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
@@ -1308,6 +1308,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
                 new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
                 RoutePatternFactory.Parse(template),
                 defaults,
+                requiredKeys: defaults.Keys,
                 parameterPolicyFactory);
 
             // Act


### PR DESCRIPTION
Will be sending batches of small-ish improvments to LinkGenerator perf here. I'll be using `LinkGenerationGithubBenchmark` - this isn't a great benchmark in it's current state but it's useful enough as everything I'm doing so far is low-hanging fruit.

Note that since this benchmark is using `TreeRouter` as its baseline, anything we do that improves the `TemplateBinder` will also improve the `LinkGenerator` as this piece of infrastructure is shared.

----

**ORIGINAL**

|          Method |     Mean |     Error |    StdDev |      Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
|---------------- |---------:|----------:|----------:|----------:|-------:|---------:|-------:|----------:|
|      TreeRouter | 2.158 us | 0.0136 us | 0.0121 us | 463,336.5 |   1.00 |     0.00 | 0.0114 |   1.14 KB |
| EndpointRouting | 4.115 us | 0.0383 us | 0.0340 us | 242,988.8 |   1.91 |     0.02 | 0.0229 |   2.16 KB |

----

**Add caching of TemplateBinder to LinkGenerator**

|          Method |     Mean |     Error |    StdDev |      Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
|---------------- |---------:|----------:|----------:|----------:|-------:|---------:|-------:|----------:|
|      TreeRouter | 2.231 us | 0.0443 us | 0.0885 us | 448,318.6 |   1.00 |     0.00 | 0.0114 |   1.14 KB |
| EndpointRouting | 3.583 us | 0.0086 us | 0.0062 us | 279,108.8 |   1.61 |     0.06 | 0.0191 |   1.77 KB |

This is an important step, because many of the rest of the optimizations we will make will rely on caching more data up front in `TemplateBinder`. Note that the existing old routing code paths already cache template binder instances.

----

**Add a synthetic baseline**

|          Method |       Mean |     Error |    StdDev |        Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
|---------------- |-----------:|----------:|----------:|------------:|-------:|---------:|-------:|----------:|
|        Baseline |   374.0 ns |  6.109 ns |  5.714 ns | 2,674,044.4 |   1.00 |     0.00 | 0.0010 |     112 B |
|      TreeRouter | 2,280.8 ns | 45.307 ns | 50.359 ns |   438,445.5 |   6.10 |     0.16 | 0.0114 |    1168 B |
| EndpointRouting | 3,620.2 ns | 30.286 ns | 25.290 ns |   276,228.7 |   9.68 |     0.16 | 0.0153 |    1808 B |

Adding a baseline based on RVD + `string.Format`. This helps with context, because this is similar to what someone would do naively if they hand-rolled link generation. As you can see we're 6-10x slower (but with a lot more features). I doubt we'll beat this, but we should try to get within 2-3x.

----

**Move require keys to constructor**

|          Method |       Mean |     Error |   StdDev |     Median |        Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
|---------------- |-----------:|----------:|---------:|-----------:|------------:|-------:|---------:|-------:|----------:|
|        Baseline |   357.7 ns |  7.068 ns | 12.56 ns |   351.6 ns | 2,795,693.2 |   1.00 |     0.00 | 0.0010 |     112 B |
|      TreeRouter | 2,230.5 ns | 43.497 ns | 44.67 ns | 2,218.8 ns |   448,329.7 |   6.24 |     0.24 | 0.0153 |    1168 B |
| EndpointRouting | 3,513.3 ns | 23.199 ns | 21.70 ns | 3,511.8 ns |   284,635.8 |   9.83 |     0.33 | 0.0191 |    1720 B |

The change here just looks like noise, but since this data is totally static, this is a change I wanted to make anyway.

----

**Inline RouteValueDictionary.Enumerator.MoveNext()**

**Before**

|                           Method |       Mean |     Error |    StdDev |          Op/s |  Gen 0 | Allocated |
|--------------------------------- |-----------:|----------:|----------:|--------------:|-------:|----------:|
|                    AddSingleItem |  25.674 ns | 0.6754 ns | 0.7507 ns |  38,949,914.8 | 0.0014 |     128 B |
|                    AddThreeItems |  47.450 ns | 0.9756 ns | 0.8648 ns |  21,075,037.0 | 0.0014 |     128 B |
|          ForEachThreeItems_Array |  37.850 ns | 0.8199 ns | 1.1223 ns |  26,420,054.0 |      - |       0 B |
|     ForEachThreeItems_Properties |  70.011 ns | 0.6198 ns | 0.5494 ns |  14,283,368.7 |      - |       0 B |
|              GetThreeItems_Array |  35.798 ns | 0.5689 ns | 0.5321 ns |  27,934,391.6 |      - |       0 B |
|         GetThreeItems_Properties | 102.160 ns | 1.9926 ns | 2.0463 ns |   9,788,545.5 |      - |       0 B |
|                    SetSingleItem |  26.321 ns | 0.5732 ns | 0.6371 ns |  37,992,393.4 | 0.0014 |     128 B |
|                  SetExistingItem |   8.059 ns | 0.2318 ns | 0.5686 ns | 124,089,448.2 |      - |       0 B |
|                    SetThreeItems |  55.578 ns | 1.2162 ns | 1.4478 ns |  17,992,752.5 | 0.0013 |     128 B |
|      TryGetValueThreeItems_Array |  42.096 ns | 0.6717 ns | 0.5955 ns |  23,755,317.1 |      - |       0 B |
| TryGetValueThreeItems_Properties | 108.665 ns | 1.4041 ns | 1.3134 ns |   9,202,624.2 |      - |       0 B |

**After**

|                           Method |       Mean |     Error |    StdDev |          Op/s |  Gen 0 | Allocated |
|--------------------------------- |-----------:|----------:|----------:|--------------:|-------:|----------:|
|                    AddSingleItem |  25.299 ns | 0.5758 ns | 0.6161 ns |  39,527,730.0 | 0.0014 |     128 B |
|                    AddThreeItems |  46.090 ns | 0.1929 ns | 0.1611 ns |  21,696,905.9 | 0.0014 |     128 B |
|          ForEachThreeItems_Array |  28.433 ns | 0.6276 ns | 0.5870 ns |  35,170,335.6 |      - |       0 B |
|     ForEachThreeItems_Properties |  86.650 ns | 1.0807 ns | 1.0109 ns |  11,540,619.4 |      - |       0 B |
|              GetThreeItems_Array |  34.724 ns | 0.7203 ns | 0.6386 ns |  28,798,117.2 |      - |       0 B |
|         GetThreeItems_Properties | 105.932 ns | 1.6163 ns | 1.4328 ns |   9,439,976.9 |      - |       0 B |
|                    SetSingleItem |  25.635 ns | 0.4527 ns | 0.3780 ns |  39,008,981.5 | 0.0015 |     128 B |
|                  SetExistingItem |   7.581 ns | 0.0414 ns | 0.0387 ns | 131,912,083.0 |      - |       0 B |
|                    SetThreeItems |  53.223 ns | 0.3683 ns | 0.3075 ns |  18,788,914.3 | 0.0013 |     128 B |
|      TryGetValueThreeItems_Array |  41.432 ns | 0.8117 ns | 0.6778 ns |  24,135,851.9 |      - |       0 B |
| TryGetValueThreeItems_Properties | 112.407 ns | 1.2656 ns | 1.1838 ns |   8,896,226.5 |      - |       0 B |

----

**ThrowHelper for RVD keys**

|                           Method |       Mean |     Error |    StdDev |          Op/s |  Gen 0 | Allocated |
|--------------------------------- |-----------:|----------:|----------:|--------------:|-------:|----------:|
|                    AddSingleItem |  26.249 ns | 0.6003 ns | 1.0029 ns |  38,096,944.7 | 0.0015 |     128 B |
|                    AddThreeItems |  47.206 ns | 1.0000 ns | 1.3003 ns |  21,183,860.8 | 0.0014 |     128 B |
|          ForEachThreeItems_Array |  27.826 ns | 0.3924 ns | 0.3671 ns |  35,937,015.3 |      - |       0 B |
|     ForEachThreeItems_Properties |  83.445 ns | 0.5780 ns | 0.4179 ns |  11,983,932.1 |      - |       0 B |
|              GetThreeItems_Array |  37.869 ns | 0.1254 ns | 0.1111 ns |  26,407,170.4 |      - |       0 B |
|         GetThreeItems_Properties | 108.817 ns | 0.7426 ns | 0.5369 ns |   9,189,773.1 |      - |       0 B |
|                    SetSingleItem |  26.168 ns | 0.5936 ns | 1.1148 ns |  38,215,340.8 | 0.0015 |     128 B |
|                  SetExistingItem |   7.518 ns | 0.1806 ns | 0.1690 ns | 133,021,088.3 |      - |       0 B |
|                    SetThreeItems |  49.023 ns | 0.9677 ns | 0.9052 ns |  20,398,701.3 | 0.0014 |     128 B |
|      TryGetValueThreeItems_Array |  39.660 ns | 0.6776 ns | 0.6338 ns |  25,214,193.4 |      - |       0 B |
| TryGetValueThreeItems_Properties | 109.138 ns | 0.4628 ns | 0.3613 ns |   9,162,729.9 |      - |       0 B |

There's a pretty good improvement getting/setting items directly. A lot of this seems like noise, but it's a good change to make. 