### PR TITLE
Fix #629 - Add logging to DfaMatcher

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
@@ -421,8 +421,8 @@ namespace Microsoft.AspNetCore.Routing
                 LogLevel.Debug,
                 EventIds.TemplateFailedExpansion,
                 "Failed to process the template {Template} for {Endpoint}. " +
-                "The failure occured while expanding the template with values {Values}. " +
-                "This is usually due to a missing or empty value in a complex segment.");
+                "The failure occured while expanding the template with values {Values} " +
+                "This is usually due to a missing or empty value in a complex segment");
 
             private static readonly Action<ILogger, IEnumerable<string>, string, Exception> _linkGenerationSucceeded = LoggerMessage.Define<IEnumerable<string>, string>(
                 LogLevel.Debug,

--- a/src/Microsoft.AspNetCore.Routing/EndpointMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Routing/EndpointMiddleware.cs
@@ -57,12 +57,12 @@ namespace Microsoft.AspNetCore.Routing
             private static readonly Action<ILogger, string, Exception> _executingEndpoint = LoggerMessage.Define<string>(
                 LogLevel.Information,
                 new EventId(0, "ExecutingEndpoint"),
-                "Executing endpoint '{EndpointName}'.");
+                "Executing endpoint '{EndpointName}'");
 
             private static readonly Action<ILogger, string, Exception> _executedEndpoint = LoggerMessage.Define<string>(
                 LogLevel.Information,
                 new EventId(1, "ExecutedEndpoint"),
-                "Executed endpoint '{EndpointName}'.");
+                "Executed endpoint '{EndpointName}'");
 
             public static void ExecutingEndpoint(ILogger logger, Endpoint endpoint)
             {

--- a/src/Microsoft.AspNetCore.Routing/EndpointRoutingMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Routing/EndpointRoutingMiddleware.cs
@@ -119,12 +119,12 @@ namespace Microsoft.AspNetCore.Routing
             private static readonly Action<ILogger, string, Exception> _matchSuccess = LoggerMessage.Define<string>(
                 LogLevel.Debug,
                 new EventId(1, "MatchSuccess"),
-                "Request matched endpoint '{EndpointName}'.");
+                "Request matched endpoint '{EndpointName}'");
 
             private static readonly Action<ILogger, Exception> _matchFailure = LoggerMessage.Define(
                 LogLevel.Debug,
                 new EventId(2, "MatchFailure"),
-                "Request did not match any endpoints.");
+                "Request did not match any endpoints");
 
             public static void MatchSuccess(ILogger logger, EndpointSelectorContext context)
             {

--- a/src/Microsoft.AspNetCore.Routing/Logging/RouteConstraintMatcherExtensions.cs
+++ b/src/Microsoft.AspNetCore.Routing/Logging/RouteConstraintMatcherExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Routing.Logging
                 LogLevel.Debug,
                 1,
                 "Route value '{RouteValue}' with key '{RouteKey}' did not match " +
-                            "the constraint '{RouteConstraint}'.");
+                            "the constraint '{RouteConstraint}'");
         }
 
         public static void RouteValueDoesNotMatchConstraint(

--- a/src/Microsoft.AspNetCore.Routing/Logging/RouterMiddlewareLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Routing/Logging/RouterMiddlewareLoggerExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Routing.Logging
             _requestDidNotMatchRoutes = LoggerMessage.Define(
                 LogLevel.Debug,
                 1,
-                "Request did not match any routes.");
+                "Request did not match any routes");
         }
 
         public static void RequestDidNotMatchRoutes(this ILogger logger)

--- a/src/Microsoft.AspNetCore.Routing/Logging/TreeRouterLoggerExtensions.cs
+++ b/src/Microsoft.AspNetCore.Routing/Logging/TreeRouterLoggerExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Routing.Logging
             _matchedRoute = LoggerMessage.Define<string, string>(
                 LogLevel.Debug,
                 1,
-                "Request successfully matched the route with name '{RouteName}' and template '{RouteTemplate}'.");
+                "Request successfully matched the route with name '{RouteName}' and template '{RouteTemplate}'");
         }
 
         public static void MatchedRoute(

--- a/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Routing.Matching
 {
@@ -13,6 +14,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
     {
         private readonly List<RouteEndpoint> _endpoints = new List<RouteEndpoint>();
 
+        private readonly ILoggerFactory _loggerFactory;
         private readonly ParameterPolicyFactory _parameterPolicyFactory;
         private readonly EndpointSelector _selector;
         private readonly MatcherPolicy[] _policies;
@@ -29,10 +31,12 @@ namespace Microsoft.AspNetCore.Routing.Matching
         private int _stateIndex;
 
         public DfaMatcherBuilder(
+            ILoggerFactory loggerFactory,
             ParameterPolicyFactory parameterPolicyFactory,
             EndpointSelector selector,
             IEnumerable<MatcherPolicy> policies)
         {
+            _loggerFactory = loggerFactory;
             _parameterPolicyFactory = parameterPolicyFactory;
             _selector = selector;
             _policies = policies.OrderBy(p => p.Order).ToArray();
@@ -304,7 +308,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 JumpTableBuilder.Build(exitDestination, exitDestination, null),
                 null);
 
-            return new DfaMatcher(_selector, states, maxSegmentCount);
+            return new DfaMatcher(_loggerFactory.CreateLogger<DfaMatcher>(), _selector, states, maxSegmentCount);
         }
 
         private int AddNode(

--- a/test/Microsoft.AspNetCore.Routing.Tests/ConstraintMatcherTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/ConstraintMatcherTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.Routing
             };
             var sink = SetUpMatch(constraints, loggerEnabled: true);
             var expectedMessage = "Route value 'value' with key 'b' did not match the constraint " +
-                $"'{typeof(FailConstraint).FullName}'.";
+                $"'{typeof(FailConstraint).FullName}'";
 
             // Assert
             Assert.Empty(sink.Scopes);

--- a/test/Microsoft.AspNetCore.Routing.Tests/EndpointRoutingMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/EndpointRoutingMiddlewareTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Routing
         public async Task Invoke_OnCall_WritesToConfiguredLogger()
         {
             // Arrange
-            var expectedMessage = "Request matched endpoint 'Test endpoint'.";
+            var expectedMessage = "Request matched endpoint 'Test endpoint'";
 
             var sink = new TestSink(
                 TestSink.EnableWithTypeName<EndpointRoutingMiddleware>,

--- a/test/Microsoft.AspNetCore.Routing.Tests/Matching/CandidateSetTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Matching/CandidateSetTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -117,6 +118,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         {
             var dataSource = new CompositeEndpointDataSource(Array.Empty<EndpointDataSource>());
             return new DfaMatcherBuilder(
+                NullLoggerFactory.Instance,
                 Mock.Of<ParameterPolicyFactory>(),
                 Mock.Of<EndpointSelector>(),
                 policies);

--- a/test/Microsoft.AspNetCore.Routing.Tests/Matching/DfaMatcherBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Matching/DfaMatcherBuilderTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -972,6 +973,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         {
             var dataSource = new CompositeEndpointDataSource(Array.Empty<EndpointDataSource>());
             return new DfaMatcherBuilder(
+                NullLoggerFactory.Instance,
                 new DefaultParameterPolicyFactory(Options.Create(new RouteOptions()), Mock.Of<IServiceProvider>()),
                 Mock.Of<EndpointSelector>(),
                 policies);

--- a/test/Microsoft.AspNetCore.Routing.Tests/RouterMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/RouterMiddlewareTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Routing
         public async Task Invoke_LogsCorrectValues_WhenNotHandled()
         {
             // Arrange
-            var expectedMessage = "Request did not match any routes.";
+            var expectedMessage = "Request did not match any routes";
             var isHandled = false;
 
             var sink = new TestSink(


### PR DESCRIPTION
Adds logging for the most common things that can prevent an endpoint
from matching.

Note that we already have good logging in other parts of the system, the
stuff here completes the story by providing details at the debug level.