### PR TITLE
Fix Routing#837

### DIFF
--- a/test/Microsoft.AspNetCore.Routing.Tests/EndpointRoutingMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/EndpointRoutingMiddlewareTest.cs
@@ -2,14 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Routing.Matching;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Routing
@@ -103,6 +106,29 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Equal("testValue", routeValuesFeature.RouteValues["testKey"]);
         }
 
+        [Fact]
+        public async Task Invoke_InitializationFailure_AllowsReinitialization()
+        {
+            // Arrange
+            var httpContext = CreateHttpContext();
+
+            var matcherFactory = new Mock<MatcherFactory>();
+            matcherFactory
+                .Setup(f => f.CreateMatcher(It.IsAny<EndpointDataSource>()))
+                .Throws(new InvalidTimeZoneException())
+                .Verifiable();
+
+            var middleware = CreateMiddleware(matcherFactory: matcherFactory.Object);
+
+            // Act
+            await Assert.ThrowsAsync<InvalidTimeZoneException>(async () => await middleware.Invoke(httpContext));
+            await Assert.ThrowsAsync<InvalidTimeZoneException>(async () => await middleware.Invoke(httpContext));
+
+            // Assert
+            matcherFactory
+                .Verify(f => f.CreateMatcher(It.IsAny<EndpointDataSource>()), Times.Exactly(2));
+        }
+
         private HttpContext CreateHttpContext()
         {
             var context = new EndpointSelectorContext();
@@ -116,14 +142,16 @@ namespace Microsoft.AspNetCore.Routing
             return httpContext;
         }
 
-        private EndpointRoutingMiddleware CreateMiddleware(Logger<EndpointRoutingMiddleware> logger = null)
+        private EndpointRoutingMiddleware CreateMiddleware(
+            Logger<EndpointRoutingMiddleware> logger = null,
+            MatcherFactory matcherFactory = null)
         {
             RequestDelegate next = (c) => Task.FromResult<object>(null);
 
             logger = logger ?? new Logger<EndpointRoutingMiddleware>(NullLoggerFactory.Instance);
+            matcherFactory = matcherFactory ?? new TestMatcherFactory(true);
 
             var options = Options.Create(new EndpointOptions());
-            var matcherFactory = new TestMatcherFactory(true);
             var middleware = new EndpointRoutingMiddleware(
                 matcherFactory,
                 new CompositeEndpointDataSource(Array.Empty<EndpointDataSource>()),


### PR DESCRIPTION
Fixes a few issues with how we initialize the middleare.
- Always completes the intitialization task
- Avoids capturing the ExecutionContext
- Allows initialization to occur repeatedly when it fails