### PR TITLE
Misc polishing

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultLinkGenerator.cs
@@ -202,7 +202,7 @@ namespace Microsoft.AspNetCore.Routing
 
         private List<RouteEndpoint> GetEndpoints<TAddress>(TAddress address)
         {
-            var addressingScheme = _serviceProvider.GetRequiredService<IEndpointFinder<TAddress>>();
+            var addressingScheme = _serviceProvider.GetRequiredService<IEndpointAddressScheme<TAddress>>();
             var endpoints = addressingScheme.FindEndpoints(address).OfType<RouteEndpoint>().ToList();
 
             if (endpoints.Count == 0)

--- a/src/Microsoft.AspNetCore.Routing/DependencyInjection/RoutingServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Routing/DependencyInjection/RoutingServiceCollectionExtensions.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Link generation related services
             services.TryAddSingleton<LinkGenerator, DefaultLinkGenerator>();
-            services.TryAddSingleton<IEndpointFinder<string>, EndpointNameEndpointFinder>();
-            services.TryAddSingleton<IEndpointFinder<RouteValuesAddress>, RouteValuesBasedEndpointFinder>();
+            services.TryAddSingleton<IEndpointAddressScheme<string>, EndpointNameAddressScheme>();
+            services.TryAddSingleton<IEndpointAddressScheme<RouteValuesAddress>, RouteValuesAddressScheme>();
 
             //
             // Endpoint Selection

--- a/src/Microsoft.AspNetCore.Routing/EndpointNameAddressScheme.cs
+++ b/src/Microsoft.AspNetCore.Routing/EndpointNameAddressScheme.cs
@@ -9,11 +9,11 @@ using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Routing
 {
-    internal class EndpointNameEndpointFinder : IEndpointFinder<string>
+    internal class EndpointNameAddressScheme : IEndpointAddressScheme<string>
     {
         private readonly DataSourceDependentCache<Dictionary<string, Endpoint[]>> _cache;
 
-        public EndpointNameEndpointFinder(CompositeEndpointDataSource dataSource)
+        public EndpointNameAddressScheme(CompositeEndpointDataSource dataSource)
         {
             _cache = new DataSourceDependentCache<Dictionary<string, Endpoint[]>>(dataSource, Initialize);
         }
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Routing
 
             string GetEndpointName(Endpoint endpoint)
             {
-                if (endpoint.Metadata.GetMetadata<ISuppressLinkGenerationMetadata>() != null)
+                if (endpoint.Metadata.GetMetadata<ISuppressLinkGenerationMetadata>()?.SuppressLinkGeneration == true)
                 {
                     // Skip anything that's suppressed for linking.
                     return null;

--- a/src/Microsoft.AspNetCore.Routing/IEndpointAddressScheme.cs
+++ b/src/Microsoft.AspNetCore.Routing/IEndpointAddressScheme.cs
@@ -7,13 +7,13 @@ using Microsoft.AspNetCore.Http;
 namespace Microsoft.AspNetCore.Routing
 {
     /// <summary>
-    /// Defines a contract to find endpoints based on the supplied lookup information.
+    /// Defines a contract to find endpoints based on the provided address.
     /// </summary>
     /// <typeparam name="TAddress">The address type to look up endpoints.</typeparam>
-    public interface IEndpointFinder<TAddress>
+    public interface IEndpointAddressScheme<TAddress>
     {
         /// <summary>
-        /// Finds endpoints based on the supplied lookup information.
+        /// Finds endpoints based on the provided <paramref name="address"/>.
         /// </summary>
         /// <param name="address">The information used to look up endpoints.</param>
         /// <returns>A collection of <see cref="Endpoint"/>.</returns>

--- a/src/Microsoft.AspNetCore.Routing/ISuppressLinkGenerationMetadata.cs
+++ b/src/Microsoft.AspNetCore.Routing/ISuppressLinkGenerationMetadata.cs
@@ -4,10 +4,14 @@
 namespace Microsoft.AspNetCore.Routing
 {
     /// <summary>
-    /// Represents metadata used during link generation.
-    /// The associated endpoint will not be considered for link generation.
+    /// Represents metadata used during link generation. If <see cref="SuppressLinkGeneration"/> is <c>true</c> 
+    /// the associated endpoint will not be used for link generation.
     /// </summary>
     public interface ISuppressLinkGenerationMetadata
     {
+        /// <summary>
+        /// Gets a value indicating whether the assocated endpoint should be used for link generation.
+        /// </summary>
+        bool SuppressLinkGeneration { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Routing/ISuppressMatchingMetadata.cs
+++ b/src/Microsoft.AspNetCore.Routing/ISuppressMatchingMetadata.cs
@@ -4,10 +4,14 @@
 namespace Microsoft.AspNetCore.Routing
 {
     /// <summary>
-    /// Metadata used to prevent URL matching. The associated endpoint will not be
-    /// considered URL matching for incoming requests.
+    /// Metadata used to prevent URL matching. If <see cref="SuppressMatching"/> is <c>true</c> the
+    /// associated endpoint will not be considered for URL matching.
     /// </summary>
     public interface ISuppressMatchingMetadata
     {
+        /// <summary>
+        /// Gets a value indicating whether the assocated endpoint should be used for URL matching.
+        /// </summary>
+        bool SuppressMatching { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Routing/Internal/DfaGraphWriter.cs
+++ b/src/Microsoft.AspNetCore.Routing/Internal/DfaGraphWriter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
             var endpoints = dataSource.Endpoints;
             for (var i = 0; i < endpoints.Count; i++)
             {
-                if (endpoints[i] is RouteEndpoint endpoint && endpoint.Metadata.GetMetadata<ISuppressMatchingMetadata>() == null)
+                if (endpoints[i] is RouteEndpoint endpoint && endpoint.Metadata.GetMetadata<ISuppressMatchingMetadata>()?.SuppressMatching == true)
                 {
                     builder.AddEndpoint(endpoint);
                 }

--- a/src/Microsoft.AspNetCore.Routing/Matching/DataSourceDependentMatcher.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/DataSourceDependentMatcher.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 // By design we only look at RouteEndpoint here. It's possible to
                 // register other endpoint types, which are non-routable, and it's
                 // ok that we won't route to them.
-                if (endpoints[i] is RouteEndpoint endpoint && endpoint.Metadata.GetMetadata<ISuppressMatchingMetadata>() == null)
+                if (endpoints[i] is RouteEndpoint endpoint && endpoint.Metadata.GetMetadata<ISuppressMatchingMetadata>()?.SuppressMatching != true)
                 {
                     builder.AddEndpoint(endpoint);
                 }

--- a/src/Microsoft.AspNetCore.Routing/RouteValuesAddressScheme.cs
+++ b/src/Microsoft.AspNetCore.Routing/RouteValuesAddressScheme.cs
@@ -12,13 +12,13 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.Routing
 {
-    internal class RouteValuesBasedEndpointFinder : IEndpointFinder<RouteValuesAddress>
+    internal class RouteValuesAddressScheme : IEndpointAddressScheme<RouteValuesAddress>
     {
         private readonly CompositeEndpointDataSource _dataSource;
         private LinkGenerationDecisionTree _allMatchesLinkGenerationTree;
         private IDictionary<string, List<OutboundMatchResult>> _namedMatchResults;
 
-        public RouteValuesBasedEndpointFinder(CompositeEndpointDataSource dataSource)
+        public RouteValuesAddressScheme(CompositeEndpointDataSource dataSource)
         {
             _dataSource = dataSource;
 
@@ -102,9 +102,7 @@ namespace Microsoft.AspNetCore.Routing
             var endpoints = _dataSource.Endpoints.OfType<RouteEndpoint>();
             foreach (var endpoint in endpoints)
             {
-                // Do not consider an endpoint for link generation if the following marker metadata is on it
-                var suppressLinkGeneration = endpoint.Metadata.GetMetadata<ISuppressLinkGenerationMetadata>();
-                if (suppressLinkGeneration != null)
+                if (endpoint.Metadata.GetMetadata<ISuppressLinkGenerationMetadata>()?.SuppressLinkGeneration == true)
                 {
                     continue;
                 }

--- a/src/Microsoft.AspNetCore.Routing/SuppressLinkGenerationMetadata.cs
+++ b/src/Microsoft.AspNetCore.Routing/SuppressLinkGenerationMetadata.cs
@@ -4,10 +4,14 @@
 namespace Microsoft.AspNetCore.Routing
 {
     /// <summary>
-    /// Represents metadata used during link generation.
-    /// The associated endpoint will not be considered for link generation.
+    /// Represents metadata used during link generation. If <see cref="SuppressLinkGeneration"/> is <c>true</c> 
+    /// the associated endpoint will not be used for link generation.
     /// </summary>
     public sealed class SuppressLinkGenerationMetadata : ISuppressLinkGenerationMetadata
     {
+        /// <summary>
+        /// Gets a value indicating whether the assocated endpoint should be used for link generation.
+        /// </summary>
+        public bool SuppressLinkGeneration => true;
     }
 }

--- a/src/Microsoft.AspNetCore.Routing/SuppressMatchingMetadata.cs
+++ b/src/Microsoft.AspNetCore.Routing/SuppressMatchingMetadata.cs
@@ -4,10 +4,14 @@
 namespace Microsoft.AspNetCore.Routing
 {
     /// <summary>
-    /// Metadata used to prevent URL matching. The associated endpoint will not be
-    /// considered URL matching for incoming requests.
+    /// Metadata used to prevent URL matching. If <see cref="SuppressMatching"/> is <c>true</c> the
+    /// associated endpoint will not be considered for URL matching.
     /// </summary>
     public sealed class SuppressMatchingMetadata : ISuppressMatchingMetadata
     {
+        /// <summary>
+        /// Gets a value indicating whether the assocated endpoint should be used for URL matching.
+        /// </summary>
+        public bool SuppressMatching => true;
     }
 }

--- a/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
@@ -599,14 +599,14 @@ namespace Microsoft.AspNetCore.Routing
 
         protected override void AddAdditionalServices(IServiceCollection services)
         {
-            services.AddSingleton<IEndpointFinder<int>, IntEndpointFinder>();
+            services.AddSingleton<IEndpointAddressScheme<int>, IntAddressScheme>();
         }
 
-        private class IntEndpointFinder : IEndpointFinder<int>
+        private class IntAddressScheme : IEndpointAddressScheme<int>
         {
             private readonly CompositeEndpointDataSource _dataSource;
 
-            public IntEndpointFinder(CompositeEndpointDataSource dataSource)
+            public IntAddressScheme(CompositeEndpointDataSource dataSource)
             {
                 _dataSource = dataSource;
             }

--- a/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorEndpointNameExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorEndpointNameExtensionsTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Routing
     // Does not cover template processing in detail, those scenarios are validated by TemplateBinderTests
     // and DefaultLinkGeneratorProcessTemplateTest
     //
-    // Does not cover the EndpointNameEndpointFinder in detail. see EndpointNameEndpointFinderTest
+    // Does not cover the EndpointNameAddressScheme in detail. see EndpointNameAddressSchemeTest
     public class LinkGeneratorEndpointNameExtensionsTest : LinkGeneratorTestBase
     {
         [Fact]

--- a/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/LinkGeneratorRouteValuesAddressExtensionsTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Routing
     // Does not cover template processing in detail, those scenarios are validated by TemplateBinderTests
     // and DefaultLinkGeneratorProcessTemplateTest
     //
-    // Does not cover the RouteValueBasedEndpointFinder in detail. see RouteValueBasedEndpointFinderTest
+    // Does not cover the RouteValuesAddressScheme in detail. see RouteValuesAddressSchemeTest
     public class LinkGeneratorRouteValuesAddressExtensionsTest : LinkGeneratorTestBase
     {
         [Fact]

--- a/test/Microsoft.AspNetCore.Routing.Tests/Matching/DataSourceDependentMatcherTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Matching/DataSourceDependentMatcherTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Xunit;
@@ -90,6 +89,27 @@ namespace Microsoft.AspNetCore.Routing.Matching
         }
 
         [Fact]
+        public void Matcher_UnsuppressedEndpoint_IsUsed()
+        {
+            // Arrange
+            var dataSource = new DynamicEndpointDataSource();
+            var endpoint = new RouteEndpoint(
+                TestConstants.EmptyRequestDelegate,
+                RoutePatternFactory.Parse("/"),
+                0,
+                new EndpointMetadataCollection(new SuppressMatchingMetadata(), new EncourageMatchingMetadata()),
+                "test");
+            dataSource.AddEndpoint(endpoint);
+
+            // Act
+            var matcher = new DataSourceDependentMatcher(dataSource, TestMatcherBuilder.Create);
+
+            // Assert
+            var inner = Assert.IsType<TestMatcher>(matcher.CurrentMatcher);
+            Assert.Same(endpoint, Assert.Single(inner.Endpoints));
+        }
+
+        [Fact]
         public void Cache_Reinitializes_WhenDataSourceChanges()
         {
             // Arrange
@@ -138,6 +158,11 @@ namespace Microsoft.AspNetCore.Routing.Matching
             {
                 throw new NotImplementedException();
             }
+        }
+
+        private class EncourageMatchingMetadata : ISuppressMatchingMetadata
+        {
+            public bool SuppressMatching => false;
         }
     }
 }


### PR DESCRIPTION
Rename `IEndpointFinder<>` -> `IAddressScheme<>`

Address the two 'marker' metadata types that I'm aware of.