### PR TITLE
Minor performance improvement for DfaMatcherBuilder

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/DfaMatcherBuilderBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/Matching/DfaMatcherBuilderBenchmark.cs
@@ -1,0 +1,217 @@
+﻿using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.TestObjects;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Routing.Matching
+{
+    public class DfaMatcherBuilderBenchmark
+    {
+        private IEnumerable<MatcherPolicy> _policies;
+        private ILoggerFactory _loggerFactory;
+        private DefaultParameterPolicyFactory _parameterPolicyFactory;
+        private RouteEndpoint[] _endpoints;
+        private EndpointSelector _selector;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _policies = new List<MatcherPolicy>()
+                {
+                    CreateNodeBuilderPolicy(4),
+                    CreateUberPolicy(2),
+                    CreateNodeBuilderPolicy(3),
+                    CreateEndpointComparerPolicy(5),
+                    CreateNodeBuilderPolicy(1),
+                    CreateEndpointSelectorPolicy(9),
+                    CreateEndpointComparerPolicy(7),
+                    CreateNodeBuilderPolicy(6),
+                    CreateEndpointSelectorPolicy(10),
+                    CreateUberPolicy(12),
+                    CreateEndpointComparerPolicy(11)
+                };
+            _loggerFactory = NullLoggerFactory.Instance;
+            _selector = new DefaultEndpointSelector();
+            _parameterPolicyFactory = new DefaultParameterPolicyFactory(Options.Create(new RouteOptions()), new TestServiceProvider());
+            _endpoints = new RouteEndpoint[12]
+                {
+                    CreateEndpoint("/account", "GET"),
+                    CreateEndpoint("/analyze", "POST"),
+                    CreateEndpoint("/apis", "GET"),
+                    CreateEndpoint("/Applications", "GET"),
+                    CreateEndpoint("/ApplicationTypes", "GET"),
+                    CreateEndpoint("/apps/", "GET"),
+                    CreateEndpoint("/apps/", "POST"),
+                    CreateEndpoint("/authorizationServers", "GET"),
+                    CreateEndpoint("/backends", "GET"),
+                    CreateEndpoint("/BuildJob", "POST"),
+                    CreateEndpoint("/certificates", "POST"),
+                    CreateEndpoint("/certificates", "GET")
+                };
+        }
+
+        [Benchmark]
+        public void Ctor()
+        {
+            new DfaMatcherBuilder(_loggerFactory, _parameterPolicyFactory, _selector, _policies);
+        }
+
+        [Benchmark]
+        public void ConstructAndBuild()
+        {
+            var builder = new DfaMatcherBuilder(_loggerFactory, _parameterPolicyFactory, _selector, _policies);
+
+            for (var i = 0; i < _endpoints.Length; i++)
+                builder.AddEndpoint(_endpoints[i]);
+
+            builder.Build();
+        }
+
+        private static RouteEndpoint CreateEndpoint(string template, string httpMethod)
+        {
+            return CreateEndpoint(template, metadata: new object[]
+            {
+                new HttpMethodMetadata(new string[]{ httpMethod, }),
+            });
+        }
+
+        private static RouteEndpoint CreateEndpoint(string template, params object[] metadata)
+        {
+            var endpointMetadata = new List<object>(metadata ?? Array.Empty<object>());
+
+            return new RouteEndpoint(
+                (context) => Task.CompletedTask,
+                RoutePatternFactory.Parse(template, null, null),
+                0,
+                new EndpointMetadataCollection(endpointMetadata),
+                null);
+        }
+
+        private static MatcherPolicy CreateNodeBuilderPolicy(int order)
+        {
+            return new TestNodeBuilderPolicy(order);
+        }
+        private static MatcherPolicy CreateEndpointComparerPolicy(int order)
+        {
+            return new TestEndpointComparerPolicy(order);
+        }
+
+        private static MatcherPolicy CreateEndpointSelectorPolicy(int order)
+        {
+            return new TestEndpointSelectorPolicy(order);
+        }
+
+        private static MatcherPolicy CreateUberPolicy(int order)
+        {
+            return new TestUberPolicy(order);
+        }
+
+        private class TestUberPolicy : TestMatcherPolicyBase, INodeBuilderPolicy, IEndpointComparerPolicy
+        {
+            public TestUberPolicy(int order) : base(order)
+            {
+            }
+
+            public IComparer<Endpoint> Comparer => new TestEndpointComparer();
+
+            public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+            {
+                return false;
+            }
+
+            public PolicyJumpTable BuildJumpTable(int exitDestination, IReadOnlyList<PolicyJumpTableEdge> edges)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IReadOnlyList<PolicyNodeEdge> GetEdges(IReadOnlyList<Endpoint> endpoints)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class TestNodeBuilderPolicy : TestMatcherPolicyBase, INodeBuilderPolicy
+        {
+            public TestNodeBuilderPolicy(int order) : base(order)
+            {
+            }
+
+            public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+            {
+                return false;
+            }
+
+            public PolicyJumpTable BuildJumpTable(int exitDestination, IReadOnlyList<PolicyJumpTableEdge> edges)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IReadOnlyList<PolicyNodeEdge> GetEdges(IReadOnlyList<Endpoint> endpoints)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class TestEndpointComparerPolicy : TestMatcherPolicyBase, IEndpointComparerPolicy
+        {
+            public TestEndpointComparerPolicy(int order) : base(order)
+            {
+            }
+
+            public IComparer<Endpoint> Comparer => new TestEndpointComparer();
+
+            public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+            {
+                return false;
+            }
+
+            public Task ApplyAsync(HttpContext httpContext, EndpointSelectorContext context, CandidateSet candidates)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class TestEndpointSelectorPolicy : TestMatcherPolicyBase, IEndpointSelectorPolicy
+        {
+            public TestEndpointSelectorPolicy(int order) : base(order)
+            {
+            }
+
+            public bool AppliesToEndpoints(IReadOnlyList<Endpoint> endpoints)
+            {
+                return false;
+            }
+
+            public Task ApplyAsync(HttpContext httpContext, EndpointSelectorContext context, CandidateSet candidates)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private abstract class TestMatcherPolicyBase : MatcherPolicy
+        {
+            private int _order;
+
+            protected TestMatcherPolicyBase(int order)
+            {
+                _order = order;
+            }
+
+            public override int Order { get { return _order; } }
+        }
+
+        private class TestEndpointComparer : IComparer<Endpoint>
+        {
+            public int Compare(Endpoint x, Endpoint y)
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Matching/DfaMatcherBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Routing.Matching
         private readonly ILoggerFactory _loggerFactory;
         private readonly ParameterPolicyFactory _parameterPolicyFactory;
         private readonly EndpointSelector _selector;
-        private readonly MatcherPolicy[] _policies;
+        private readonly IEndpointSelectorPolicy[] _endpointSelectorPolicies;
         private readonly INodeBuilderPolicy[] _nodeBuilders;
         private readonly EndpointComparer _comparer;
 
@@ -39,11 +39,12 @@ namespace Microsoft.AspNetCore.Routing.Matching
             _loggerFactory = loggerFactory;
             _parameterPolicyFactory = parameterPolicyFactory;
             _selector = selector;
-            _policies = policies.OrderBy(p => p.Order).ToArray();
 
-            // Taking care to use _policies, which has been sorted.
-            _nodeBuilders = _policies.OfType<INodeBuilderPolicy>().ToArray();
-            _comparer = new EndpointComparer(_policies.OfType<IEndpointComparerPolicy>().ToArray());
+            var extractedPolicies = ExtractPolicies(policies.OrderBy(p => p.Order));
+
+            _endpointSelectorPolicies = extractedPolicies.endpointSelectorPolicies;
+            _nodeBuilders = extractedPolicies.nodeBuilderPolicies;
+            _comparer = new EndpointComparer(extractedPolicies.endpointComparerPolicies);
 
             _assignments = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
             _slots = new List<KeyValuePair<string, object>>();
@@ -383,10 +384,10 @@ namespace Microsoft.AspNetCore.Routing.Matching
             List<IEndpointSelectorPolicy> endpointSelectorPolicies = null;
             if (node.Matches?.Count > 0)
             {
-                for (var i = 0; i < _policies.Length; i++)
+                for (var i = 0; i < _endpointSelectorPolicies.Length; i++)
                 {
-                    if (_policies[i] is IEndpointSelectorPolicy endpointSelectorPolicy &&
-                        endpointSelectorPolicy.AppliesToEndpoints(node.Matches))
+                    var endpointSelectorPolicy = _endpointSelectorPolicies[i];
+                    if (endpointSelectorPolicy.AppliesToEndpoints(node.Matches))
                     {
                         if (endpointSelectorPolicies == null)
                         {
@@ -465,16 +466,16 @@ namespace Microsoft.AspNetCore.Routing.Matching
         // internal for tests
         internal Candidate CreateCandidate(Endpoint endpoint, int score)
         {
-            _assignments.Clear();
-            _slots.Clear();
-            _captures.Clear();
-            _complexSegments.Clear();
-            _constraints.Clear();
-
             (string parameterName, int segmentIndex, int slotIndex) catchAll = default;
 
             if (endpoint is RouteEndpoint routeEndpoint)
             {
+                _assignments.Clear();
+                _slots.Clear();
+                _captures.Clear();
+                _complexSegments.Clear();
+                _constraints.Clear();
+
                 foreach (var kvp in routeEndpoint.RoutePattern.Defaults)
                 {
                     _assignments.Add(kvp.Key, _assignments.Count);
@@ -539,16 +540,27 @@ namespace Microsoft.AspNetCore.Routing.Matching
                         }
                     }
                 }
-            }
 
-            return new Candidate(
-                endpoint,
-                score,
-                _slots.ToArray(),
-                _captures.ToArray(),
-                catchAll,
-                _complexSegments.ToArray(),
-                _constraints.ToArray());
+                return new Candidate(
+                    endpoint,
+                    score,
+                    _slots.ToArray(),
+                    _captures.ToArray(),
+                    catchAll,
+                    _complexSegments.ToArray(),
+                    _constraints.ToArray());
+            }
+            else
+            {
+                return new Candidate(
+                    endpoint,
+                    score,
+                    Array.Empty<KeyValuePair<string, object>>(),
+                    Array.Empty<(string parameterName, int segmentIndex, int slotIndex)>(),
+                    catchAll,
+                    Array.Empty<(RoutePatternPathSegment pathSegment, int segmentIndex)>(),
+                    Array.Empty<KeyValuePair<string, IRouteConstraint>>());
+            }
         }
 
         private int[] GetGroupLengths(DfaNode node)
@@ -681,6 +693,33 @@ namespace Microsoft.AspNetCore.Routing.Matching
                 previousWork = work;
                 work = nextWork;
             }
+        }
+
+        private static (INodeBuilderPolicy[] nodeBuilderPolicies, IEndpointComparerPolicy[] endpointComparerPolicies, IEndpointSelectorPolicy[] endpointSelectorPolicies) ExtractPolicies(IEnumerable<MatcherPolicy> policies)
+        {
+            var nodeBuilderPolicies = new List<INodeBuilderPolicy>();
+            var endpointComparerPolicies = new List<IEndpointComparerPolicy>();
+            var endpointSelectorPolicies = new List<IEndpointSelectorPolicy>();
+
+            foreach (var policy in policies)
+            {
+                if (policy is INodeBuilderPolicy nodeBuilderPolicy)
+                {
+                    nodeBuilderPolicies.Add(nodeBuilderPolicy);
+                }
+
+                if (policy is IEndpointComparerPolicy endpointComparerPolicy)
+                {
+                    endpointComparerPolicies.Add(endpointComparerPolicy);
+                }
+
+                if (policy is IEndpointSelectorPolicy endpointSelectorPolicy)
+                {
+                    endpointSelectorPolicies.Add(endpointSelectorPolicy);
+                }
+            }
+
+            return (nodeBuilderPolicies.ToArray(), endpointComparerPolicies.ToArray(), endpointSelectorPolicies.ToArray());
         }
     }
 }


### PR DESCRIPTION
* Decompose list of policies in separate array without using **Linq**.
This avoids iterating over all policies in `AddNode(DfaNode node, DfaState[] states, int exitDestination)`, and improves performance of `.ctor`, `Build()` and `BuildDfaTree(bool includeLabel = false)`.
* When endpoint is not a **RouteEndpoint**, do not bother clearing lists in `CreateCandidate(Endpoint endpoint, int score)` and use empty arrays to reduce allocations.

``` ini

BenchmarkDotNet=v0.10.13, OS=Windows 10.0.17134
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical cores and 4 physical cores
Frequency=3914069 Hz, Resolution=255.4886 ns, Timer=TSC
.NET Core SDK=2.1.400
  [Host]     : .NET Core 2.2.0-preview3-26927-02 (CoreCLR 4.6.26927.02, CoreFX 4.6.26927.02), 64bit RyuJIT
  Job-VYAOMV : .NET Core 2.2.0-preview3-26927-02 (CoreCLR 4.6.26927.02, CoreFX 4.6.26927.02), 64bit RyuJIT

Runtime=Core  Server=True  Toolchain=.NET Core 2.2  
RunStrategy=Throughput  

```

**Before**

|            Method |      Mean |     Error |    StdDev |      Op/s |  Gen 0 | Allocated |
|------------------ |----------:|----------:|----------:|----------:|-------:|----------:|
|              Ctor |  2.123 us | 0.0102 us | 0.0095 us | 470,998.0 | 0.0191 |   1.81 KB |
| ConstructAndBuild | 14.016 us | 0.0670 us | 0.0594 us |  71,347.4 | 0.1526 |   13.5 KB |

**After**

|            Method |      Mean |     Error |    StdDev |      Op/s |  Gen 0 | Allocated |
|------------------ |----------:|----------:|----------:|----------:|-------:|----------:|
|              Ctor |  1.265 us | 0.0045 us | 0.0038 us | 790,604.1 | 0.0210 |    1.8 KB |
| ConstructAndBuild | 12.562 us | 0.1081 us | 0.0959 us |  79,604.4 | 0.1526 |  13.49 KB |
