### PR TITLE
Add Remove(string key, out object value) overload to RouteValueDictionary

### DIFF
--- a/src/Microsoft.AspNetCore.Routing.Abstractions/RouteValueDictionary.cs
+++ b/src/Microsoft.AspNetCore.Routing.Abstractions/RouteValueDictionary.cs
@@ -405,6 +405,46 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         /// <summary>
+        /// Attempts to remove and return the value that has the specified key from the <see cref="RouteValueDictionary"/>.
+        /// </summary>
+        /// <param name="key">The key of the element to remove and return.</param>
+        /// <param name="value">When this method returns, contains the object removed from the <see cref="RouteValueDictionary"/>, or <c>null</c> if key does not exist.</param>
+        /// <returns>
+        /// <c>true</c> if the object was removed successfully; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Remove(string key, out object value)
+        {
+            if (key == null)
+            {
+                ThrowArgumentNullExceptionForKey();
+            }
+
+            if (Count == 0)
+            {
+                value = default;
+                return false;
+            }
+
+            EnsureCapacity(Count);
+
+            var index = FindIndex(key);
+            if (index >= 0)
+            {
+                _count--;
+                var array = _arrayStorage;
+                value = array[index].Value;
+                Array.Copy(array, index + 1, array, index, _count - index);
+                array[_count] = default;
+
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+
+        /// <summary>
         /// Attempts to the add the provided <paramref name="key"/> and <paramref name="value"/> to the dictionary.
         /// </summary>
         /// <param name="key">The key.</param>

--- a/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
@@ -471,11 +471,7 @@ namespace Microsoft.AspNetCore.Routing.Template
                     else if (part is RoutePatternParameterPart parameterPart)
                     {
                         // If it's a parameter, get its value
-                        var hasValue = acceptedValues.TryGetValue(parameterPart.Name, out var value);
-                        if (hasValue)
-                        {
-                            acceptedValues.Remove(parameterPart.Name);
-                        }
+                        acceptedValues.Remove(parameterPart.Name, out var value);
 
                         var isSameAsDefault = false;
                         if (_defaults != null &&

--- a/test/Microsoft.AspNetCore.Mvc.Routing.Abstractions.Tests/RouteValueDictionaryTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Routing.Abstractions.Tests/RouteValueDictionaryTests.cs
@@ -1393,6 +1393,161 @@ namespace Microsoft.AspNetCore.Routing.Tests
             Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
         }
 
+
+        [Fact]
+        public void Remove_KeyAndOutValue_EmptyStorage()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary();
+
+            // Act
+            var result = dict.Remove("key", out var removedValue);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(removedValue);
+        }
+
+        [Fact]
+        public void Remove_KeyAndOutValue_EmptyStringIsAllowed()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary();
+
+            // Act
+            var result = dict.Remove("", out var removedValue);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(removedValue);
+        }
+
+        [Fact]
+        public void Remove_KeyAndOutValue_PropertyStorage_Empty()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary(new { });
+
+            // Act
+            var result = dict.Remove("other", out var removedValue);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(removedValue);
+            Assert.Empty(dict);
+            Assert.NotNull(dict._propertyStorage);
+        }
+
+        [Fact]
+        public void Remove_KeyAndOutValue_PropertyStorage_False()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary(new { key = "value" });
+
+            // Act
+            var result = dict.Remove("other", out var removedValue);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(removedValue);
+            Assert.Collection(dict, kvp => { Assert.Equal("key", kvp.Key); Assert.Equal("value", kvp.Value); });
+            Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
+        }
+
+        [Fact]
+        public void Remove_KeyAndOutValue_PropertyStorage_True()
+        {
+            // Arrange
+            object value = "value";
+            var dict = new RouteValueDictionary(new { key = value });
+
+            // Act
+            var result = dict.Remove("key", out var removedValue);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(value, removedValue);
+            Assert.Empty(dict);
+            Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
+        }
+
+        [Fact]
+        public void Remove_KeyAndOutValue_PropertyStorage_True_CaseInsensitive()
+        {
+            // Arrange
+            object value = "value";
+            var dict = new RouteValueDictionary(new { key = value });
+
+            // Act
+            var result = dict.Remove("kEy", out var removedValue);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(value, removedValue);
+            Assert.Empty(dict);
+            Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
+        }
+
+        [Fact]
+        public void Remove_KeyAndOutValue_ListStorage_False()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary()
+            {
+                { "key", "value" },
+            };
+
+            // Act
+            var result = dict.Remove("other", out var removedValue);
+
+            // Assert
+            Assert.False(result);
+            Assert.Null(removedValue);
+            Assert.Collection(dict, kvp => { Assert.Equal("key", kvp.Key); Assert.Equal("value", kvp.Value); });
+            Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
+        }
+
+        [Fact]
+        public void Remove_KeyAndOutValue_ListStorage_True()
+        {
+            // Arrange
+            object value = "value";
+            var dict = new RouteValueDictionary()
+            {
+                { "key", value }
+            };
+
+            // Act
+            var result = dict.Remove("key", out var removedValue);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(value, removedValue);
+            Assert.Empty(dict);
+            Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
+        }
+
+        [Fact]
+        public void Remove_KeyAndOutValue_ListStorage_True_CaseInsensitive()
+        {
+            // Arrange
+            object value = "value";
+            var dict = new RouteValueDictionary()
+            {
+                { "key", value }
+            };
+
+            // Act
+            var result = dict.Remove("kEy", out var removedValue);
+
+            // Assert
+            Assert.True(result);
+            Assert.Same(value, removedValue);
+            Assert.Empty(dict);
+            Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
+        }
+
+
         [Fact]
         public void TryAdd_EmptyStringIsAllowed()
         {


### PR DESCRIPTION
Adds a `Remove(string key, out object value)` overload to **RouteValueDictionary**, and use it where applicable.

Note that we could also benefit from using the same overload on **Dictionary<TKey, TValue>** in other places, but we cannot since both **.NET Standard 2.0** and **.NET Core 2.2** are being target (unless we use conditional compilation).