### PR TITLE
Minor performance improvement for UriBuildingContext.ToPathString() w…

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Internal/UriBuildingContext.cs
+++ b/src/Microsoft.AspNetCore.Routing/Internal/UriBuildingContext.cs
@@ -242,18 +242,29 @@ namespace Microsoft.AspNetCore.Routing.Internal
         // Used by TemplateBinder.TryBindValues - the new code path of LinkGenerator
         public PathString ToPathString()
         {
-            if (_path.Length > 0 && _path[0] != '/')
+            PathString pathString;
+
+            if (_path.Length > 0)
             {
-                // Normalize generated paths so that they always contain a leading slash.
-                _path.Insert(0, '/');
+                if (_path[0] != '/')
+                {
+                    // Normalize generated paths so that they always contain a leading slash.
+                    _path.Insert(0, '/');
+                }
+
+                if (AppendTrailingSlash && _path[_path.Length - 1] != '/')
+                {
+                    _path.Append('/');
+                }
+
+                pathString = new PathString(_path.ToString());
+            }
+            else
+            {
+                pathString = PathString.Empty;
             }
 
-            if (AppendTrailingSlash && _path.Length > 0 && _path[_path.Length - 1] != '/')
-            {
-                _path.Append('/');
-            }
-
-            return new PathString(_path.ToString());
+            return pathString;
         }
 
         // Used by TemplateBinder.TryBindValues - the new code path of LinkGenerator

--- a/test/Microsoft.AspNetCore.Routing.Tests/Internal/UriBuildingContextTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Internal/UriBuildingContextTest.cs
@@ -65,5 +65,36 @@ namespace Microsoft.AspNetCore.Routing.Internal
             // Assert
             Assert.Equal(expected, uriBuilldingContext.ToString());
         }
+
+        [Theory]
+        [InlineData("/Author", false, false, "/UrlEncode[[Author]]")]
+        [InlineData("/Author", false, true, "/UrlEncode[[Author]]")]
+        [InlineData("/Author", true, false, "/UrlEncode[[Author]]/")]
+        [InlineData("/Author", true, true, "/UrlEncode[[Author]]/")]
+        [InlineData("/Author/", false, false, "/UrlEncode[[Author]]/")]
+        [InlineData("/Author/", false, true, "/UrlEncode[[Author/]]")]
+        [InlineData("/Author/", true, false, "/UrlEncode[[Author]]/")]
+        [InlineData("/Author/", true, true, "/UrlEncode[[Author/]]/")]
+        [InlineData("Author", false, false, "/UrlEncode[[Author]]")]
+        [InlineData("Author", false, true, "/UrlEncode[[Author]]")]
+        [InlineData("Author", true, false, "/UrlEncode[[Author]]/")]
+        [InlineData("Author", true, true, "/UrlEncode[[Author]]/")]
+        [InlineData("", false, false, "")]
+        [InlineData("", false, true, "")]
+        [InlineData("", true, false, "")]
+        [InlineData("", true, true, "")]
+        public void ToPathString(string url, bool appendTrailingSlash, bool encodeSlashes, string expected)
+        {
+            // Arrange
+            var urlTestEncoder = new UrlTestEncoder();
+            var uriBuilldingContext = new UriBuildingContext(urlTestEncoder);
+            uriBuilldingContext.AppendTrailingSlash = appendTrailingSlash;
+
+            // Act
+            uriBuilldingContext.Accept(url, encodeSlashes);
+
+            // Assert
+            Assert.Equal(expected, uriBuilldingContext.ToPathString().Value);
+        }
     }
 }


### PR DESCRIPTION
Minor performance improvement for `UriBuildingContext.ToPathString()` with zero-length path.
Added tests for UriBuildingContext.ToPathString().

**Before:**

|                                                               Method |      Mean |     Error |    StdDev |          Op/s |  Gen 0 | Allocated |
|--------------------------------------------------------------------- |----------:|----------:|----------:|--------------:|-------:|----------:|
|                      ToPathString_PathEmpty_AppendTrailingSlashFalse |  5.828 ns | 0.0271 ns | 0.0253 ns | 171,581,171.0 |      - |       0 B |
|                       ToPathString_PathEmpty_AppendTrailingSlashTrue |  5.792 ns | 0.0141 ns | 0.0132 ns | 172,653,158.9 |      - |       0 B |
**After:**

|                                                               Method |      Mean |     Error |    StdDev |          Op/s |  Gen 0 | Allocated |
|--------------------------------------------------------------------- |----------:|----------:|----------:|--------------:|-------:|----------:|
|                      ToPathString_PathEmpty_AppendTrailingSlashFalse |  1.765 ns | 0.0031 ns | 0.0028 ns | 566,483,501.4 |      - |       0 B |
|                       ToPathString_PathEmpty_AppendTrailingSlashTrue |  1.760 ns | 0.0098 ns | 0.0092 ns | 568,144,661.1 |      - |       0 B |

Benchmark is available [here](https://gist.github.com/drieseng/1958a4755d08c77b231055172a568324).