### PR TITLE
Improves performance and reduce allocations in DefaultEndpointDataSource

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/DefaultEndpointDataSource.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultEndpointDataSource.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Routing
     /// </summary>
     public sealed class DefaultEndpointDataSource : EndpointDataSource
     {
-        private readonly Endpoint[] _endpoints;
+        private readonly IReadOnlyList<Endpoint> _endpoints;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultEndpointDataSource" /> class.
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Routing
                 throw new ArgumentNullException(nameof(endpoints));
             }
 
-            _endpoints = endpoints.ToArray();
+            _endpoints = new List<Endpoint>(endpoints);
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Routing/DefaultEndpointDataSource.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultEndpointDataSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
@@ -14,15 +15,20 @@ namespace Microsoft.AspNetCore.Routing
     /// </summary>
     public sealed class DefaultEndpointDataSource : EndpointDataSource
     {
-        private readonly List<Endpoint> _endpoints;
+        private readonly Endpoint[] _endpoints;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultEndpointDataSource" /> class.
         /// </summary>
         /// <param name="endpoints">The <see cref="Endpoint"/> instances that the data source will return.</param>
         public DefaultEndpointDataSource(params Endpoint[] endpoints)
-            : this((IEnumerable<Endpoint>) endpoints)
         {
+            if (endpoints == null)
+            {
+                throw new ArgumentNullException(nameof(endpoints));
+            }
+
+            _endpoints = (Endpoint[])endpoints.Clone();
         }
 
         /// <summary>
@@ -36,8 +42,7 @@ namespace Microsoft.AspNetCore.Routing
                 throw new ArgumentNullException(nameof(endpoints));
             }
 
-            _endpoints = new List<Endpoint>();
-            _endpoints.AddRange(endpoints);
+            _endpoints = endpoints.ToArray();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.Routing/DefaultEndpointDataSource.cs
+++ b/src/Microsoft.AspNetCore.Routing/DefaultEndpointDataSource.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;

--- a/test/Microsoft.AspNetCore.Routing.Tests/DefaultEndpointDataSourceTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/DefaultEndpointDataSourceTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 
@@ -27,6 +26,34 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         [Fact]
+        public void Constructor_Params_ShouldMakeCopyOfEndpoints()
+        {
+            // Arrange
+            var endpoint1 = new Endpoint(TestConstants.EmptyRequestDelegate, EndpointMetadataCollection.Empty, "1");
+            var endpoint2 = new Endpoint(TestConstants.EmptyRequestDelegate, EndpointMetadataCollection.Empty, "2");
+            var endpoints = new[] { endpoint1, endpoint2 };
+
+            // Act
+            var dataSource = new DefaultEndpointDataSource(endpoints);
+            Array.Resize(ref endpoints, 1);
+            endpoints[0] = null;
+
+            // Assert
+            Assert.Equal(2, dataSource.Endpoints.Count);
+            Assert.Contains(endpoint1, dataSource.Endpoints);
+            Assert.Contains(endpoint2, dataSource.Endpoints);
+        }
+
+        [Fact]
+        public void Constructor_Params_ShouldThrowArgumentNullExceptionWhenEndpointsIsNull()
+        {
+            Endpoint[] endpoints = null;
+
+            var actual = Assert.Throws<ArgumentNullException>(() => new DefaultEndpointDataSource(endpoints));
+            Assert.Equal("endpoints", actual.ParamName);
+        }
+
+        [Fact]
         public void Constructor_Enumerable_EndpointsInitialized()
         {
             // Arrange & Act
@@ -40,6 +67,34 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Collection(dataSource.Endpoints,
                 endpoint => Assert.Equal("1", endpoint.DisplayName),
                 endpoint => Assert.Equal("2", endpoint.DisplayName));
+        }
+
+        [Fact]
+        public void Constructor_Enumerable_ShouldMakeCopyOfEndpoints()
+        {
+            // Arrange
+            var endpoint1 = new Endpoint(TestConstants.EmptyRequestDelegate, EndpointMetadataCollection.Empty, "1");
+            var endpoint2 = new Endpoint(TestConstants.EmptyRequestDelegate, EndpointMetadataCollection.Empty, "2");
+            var endpoints = new List<Endpoint> { endpoint1, endpoint2 };
+
+            // Act
+            var dataSource = new DefaultEndpointDataSource((IEnumerable<Endpoint>)endpoints);
+            endpoints.RemoveAt(0);
+            endpoints[0] = null;
+
+            // Assert
+            Assert.Equal(2, dataSource.Endpoints.Count);
+            Assert.Contains(endpoint1, dataSource.Endpoints);
+            Assert.Contains(endpoint2, dataSource.Endpoints);
+        }
+
+        [Fact]
+        public void Constructor_Enumerable_ShouldThrowArgumentNullExceptionWhenEndpointsIsNull()
+        {
+            IEnumerable<Endpoint> endpoints = null;
+
+            var actual = Assert.Throws<ArgumentNullException>(() => new DefaultEndpointDataSource(endpoints));
+            Assert.Equal("endpoints", actual.ParamName);
         }
     }
 }


### PR DESCRIPTION
Improves performance and reduce allocations in **DefaultEndpointDataSource**, and improves test coverage.

**Before:**

|                 Method |     Mean |     Error |    StdDev |         Op/s |  Gen 0 | Allocated |
|----------------------- |---------:|----------:|----------:|-------------:|-------:|----------:|
|     Constructor_Params | 63.06 ns | 0.2402 ns | 0.2247 ns | 15,859,022.6 | 0.0018 |     160 B |
| Constructor_Enumerable | 56.63 ns | 0.7778 ns | 0.7275 ns | 17,658,629.3 | 0.0017 |     160 B |

**After:**

|                 Method |     Mean |     Error |    StdDev |         Op/s |  Gen 0 | Allocated |
|----------------------- |---------:|----------:|----------:|-------------:|-------:|----------:|
|     Constructor_Params | 56.25 ns | 0.1883 ns | 0.1762 ns | 17,777,345.5 | 0.0014 |     120 B |
| Constructor_Enumerable | 51.05 ns | 0.2256 ns | 0.2110 ns | 19,590,400.7 | 0.0018 |     160 B |

Benchmark is available [here](https://gist.github.com/drieseng/8313f46e039a26a6b5655685dd6fa8c5).
