### PR TITLE
Fix Routing's misuse of PathString

### DIFF
--- a/test/Microsoft.AspNetCore.Routing.Tests/Internal/UriBuildingContextTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Internal/UriBuildingContextTest.cs
@@ -1,93 +1,92 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Extensions.WebEncoders.Testing;
+using System.Text.Encodings.Web;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Routing.Internal
 {
+    // Note that these tests look a little wierd. It's because each test treats the input
+    // as a single route segment that *might* contain slashes. While we're producing paths, these
+    // are unit tests for the encoding functionality.
     public class UriBuildingContextTest
     {
         [Fact]
-        public void EncodeValue_EncodesEntireValue_WhenEncodeSlashes_IsFalse()
+        public void EncodePathValue_EncodesEntireValue_WhenEncodeSlashes_IsFalse()
         {
             // Arrange
-            var urlTestEncoder = new UrlTestEncoder();
             var value = "a/b b1/c";
-            var expected = "/UrlEncode[[a/b b1/c]]";
-            var uriBuilldingContext = new UriBuildingContext(urlTestEncoder);
+            var expected = "/a%2Fb%20b1%2Fc";
+            var uriBuilldingContext = new UriBuildingContext(UrlEncoder.Default);
             
             // Act
-            uriBuilldingContext.EncodeValue(value, 0, value.Length, encodeSlashes: true);
+            uriBuilldingContext.EncodePathValue(value, 0, value.Length, encodeSlashes: true);
 
             // Assert
             Assert.Equal(expected, uriBuilldingContext.ToString());
         }
 
         [Fact]
-        public void EncodeValue_EncodesOnlySlashes_WhenEncodeSlashes_IsFalse()
+        public void EncodePathValue_EncodesOnlySlashes_WhenEncodeSlashes_IsFalse()
         {
             // Arrange
-            var urlTestEncoder = new UrlTestEncoder();
             var value = "a/b b1/c";
-            var expected = "/UrlEncode[[a]]/UrlEncode[[b b1]]/UrlEncode[[c]]";
-            var uriBuilldingContext = new UriBuildingContext(urlTestEncoder);
+            var expected = "/a/b%20b1/c";
+            var uriBuilldingContext = new UriBuildingContext(UrlEncoder.Default);
 
             // Act
-            uriBuilldingContext.EncodeValue(value, 0, value.Length, encodeSlashes: false);
+            uriBuilldingContext.EncodePathValue(value, 0, value.Length, encodeSlashes: false);
 
             // Assert
             Assert.Equal(expected, uriBuilldingContext.ToString());
         }
 
         [Theory]
-        [InlineData("a/b b1/c", 0, 2, "/UrlEncode[[a]]/")]
-        [InlineData("a/b b1/c", 3, 4, "/UrlEncode[[ b1]]/")]
-        [InlineData("a/b b1/c", 3, 5, "/UrlEncode[[ b1]]/UrlEncode[[c]]")]
+        [InlineData("a/b b1/c", 0, 2, "/a/")]
+        [InlineData("a/b b1/c", 3, 4, "/%20b1/")]
+        [InlineData("a/b b1/c", 3, 5, "/%20b1/c")]
         [InlineData("a/b b1/c/", 8, 1, "/")]
         [InlineData("/", 0, 1, "/")]
-        [InlineData("/a", 0, 2, "/UrlEncode[[a]]")]
-        [InlineData("a", 0, 1, "/UrlEncode[[a]]")]
-        [InlineData("a/", 0, 2, "/UrlEncode[[a]]/")]
-        public void EncodeValue_EncodesOnlySlashes_WithinSubsegment_WhenEncodeSlashes_IsFalse(
+        [InlineData("/a", 0, 2, "/a")]
+        [InlineData("a", 0, 1, "/a")]
+        [InlineData("a/", 0, 2, "/a/")]
+        public void EncodePathValue_EncodesOnlySlashes_WithinSubsegment_WhenEncodeSlashes_IsFalse(
             string value,
             int startIndex,
             int characterCount,
             string expected)
         {
             // Arrange
-            var urlTestEncoder = new UrlTestEncoder();
-            var uriBuilldingContext = new UriBuildingContext(urlTestEncoder);
+            var uriBuilldingContext = new UriBuildingContext(UrlEncoder.Default);
 
             // Act
-            uriBuilldingContext.EncodeValue(value, startIndex, characterCount, encodeSlashes: false);
+            uriBuilldingContext.EncodePathValue(value, startIndex, characterCount, encodeSlashes: false);
 
             // Assert
             Assert.Equal(expected, uriBuilldingContext.ToString());
         }
-
+        
         [Theory]
-        [InlineData("/Author", false, false, "/UrlEncode[[Author]]")]
-        [InlineData("/Author", false, true, "/UrlEncode[[Author]]")]
-        [InlineData("/Author", true, false, "/UrlEncode[[Author]]/")]
-        [InlineData("/Author", true, true, "/UrlEncode[[Author]]/")]
-        [InlineData("/Author/", false, false, "/UrlEncode[[Author]]/")]
-        [InlineData("/Author/", false, true, "/UrlEncode[[Author/]]")]
-        [InlineData("/Author/", true, false, "/UrlEncode[[Author]]/")]
-        [InlineData("/Author/", true, true, "/UrlEncode[[Author/]]/")]
-        [InlineData("Author", false, false, "/UrlEncode[[Author]]")]
-        [InlineData("Author", false, true, "/UrlEncode[[Author]]")]
-        [InlineData("Author", true, false, "/UrlEncode[[Author]]/")]
-        [InlineData("Author", true, true, "/UrlEncode[[Author]]/")]
+        [InlineData("/Author", false, false, "/Author")]
+        [InlineData("/Author", false, true, "/Author")]
+        [InlineData("/Author", true, false, "/Author/")]
+        [InlineData("/Author", true, true, "/Author/")]
+        [InlineData("/Author/", false, false, "/Author/")]
+        [InlineData("/Author/", false, true, "/Author%2F")]
+        [InlineData("/Author/", true, false, "/Author/")]
+        [InlineData("/Author/", true, true, "/Author%2F/")]
+        [InlineData("Author", false, false, "/Author")]
+        [InlineData("Author", false, true, "/Author")]
+        [InlineData("Author", true, false, "/Author/")]
+        [InlineData("Author", true, true, "/Author/")]
         [InlineData("", false, false, "")]
         [InlineData("", false, true, "")]
         [InlineData("", true, false, "")]
         [InlineData("", true, true, "")]
-        public void ToPathString(string url, bool appendTrailingSlash, bool encodeSlashes, string expected)
+        public void ToPathString_EncodesSlashesInsideSegment(string url, bool appendTrailingSlash, bool encodeSlashes, string expected)
         {
             // Arrange
-            var urlTestEncoder = new UrlTestEncoder();
-            var uriBuilldingContext = new UriBuildingContext(urlTestEncoder);
+            var uriBuilldingContext = new UriBuildingContext(UrlEncoder.Default);
             uriBuilldingContext.AppendTrailingSlash = appendTrailingSlash;
 
             // Act

--- a/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Template/TemplateBinderTests.cs
@@ -583,7 +583,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
         public void GetUrlVerifyEncoding()
         {
             var values = new RouteValueDictionary();
-            values.Add("controller", "#;?:@&=+$,");
+            values.Add("controller", "#;?:@&=+$,/");
             values.Add("action", "showcategory");
             values.Add("id", 123);
             values.Add("so?rt", "de?sc");
@@ -594,7 +594,7 @@ namespace Microsoft.AspNetCore.Routing.Template.Tests
                 new RouteValueDictionary(new { controller = "Home" }),
                 new RouteValueDictionary(new { controller = "home", action = "Index", id = (string)null }),
                 values,
-                "/%23;%3F%3A@%26%3D%2B$,.mvc/showcategory/123?so%3Frt=de%3Fsc&maxPrice=100");
+                "/%23;%3F:@&=+$,%2F.mvc/showcategory/123?so%3Frt=de%3Fsc&maxPrice=100");
         }
 
         [Fact]


### PR DESCRIPTION
PathString is meant to be used with *unencoded* text. So in our case, we
should only be responsible for encoding slashes we don't want to
roundtrip.

This is working fine in 2.2 but it's inefficient so I'm targeting this
at 3.0