### PR TITLE
Minor performance improvements for RouteValueDictionary

### DIFF
--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/RouteValueDictionaryBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/RouteValueDictionaryBenchmark.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Routing
             new RouteValueDictionary(_arrayValues);
         }
 
-        //[Benchmark]
+        [Benchmark]
         public RouteValueDictionary AddSingleItem()
         {
             var dictionary = new RouteValueDictionary
@@ -84,7 +84,7 @@ namespace Microsoft.AspNetCore.Routing
             _propertyValues.ContainsKey("name");
         }
 
-        //[Benchmark]
+        [Benchmark]
         public RouteValueDictionary ConditionalAdd_ContainsKeyAdd()
         {
             var dictionary = _arrayValues;

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/RouteValueDictionaryBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/RouteValueDictionaryBenchmark.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Routing
     {
         private RouteValueDictionary _arrayValues;
         private RouteValueDictionary _propertyValues;
+        private RouteValueDictionary _arrayValuesEmpty;
 
         // We modify the route value dictionaries in many of these benchmarks.
         [IterationSetup]
@@ -21,10 +22,23 @@ namespace Microsoft.AspNetCore.Routing
                 { "controller", "Home" },
                 { "id", "17" },
             };
+            _arrayValuesEmpty = new RouteValueDictionary();
             _propertyValues = new RouteValueDictionary(new { action = "Index", controller = "Home", id = "17" });
         }
 
         [Benchmark]
+        public void Ctor_Values_RouteValueDictionary_EmptyArray()
+        {
+            new RouteValueDictionary(_arrayValuesEmpty);
+        }
+
+        [Benchmark]
+        public void Ctor_Values_RouteValueDictionary_Array()
+        {
+            new RouteValueDictionary(_arrayValues);
+        }
+
+        //[Benchmark]
         public RouteValueDictionary AddSingleItem()
         {
             var dictionary = new RouteValueDictionary
@@ -47,6 +61,30 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         [Benchmark]
+        public void ContainsKey_Array_Found()
+        {
+            _arrayValues.ContainsKey("id");
+        }
+
+        [Benchmark]
+        public void ContainsKey_Array_NotFound()
+        {
+            _arrayValues.ContainsKey("name");
+        }
+
+        [Benchmark]
+        public void ContainsKey_Properties_Found()
+        {
+            _propertyValues.ContainsKey("id");
+        }
+
+        [Benchmark]
+        public void ContainsKey_Properties_NotFound()
+        {
+            _propertyValues.ContainsKey("name");
+        }
+
+        //[Benchmark]
         public RouteValueDictionary ConditionalAdd_ContainsKeyAdd()
         {
             var dictionary = _arrayValues;
@@ -68,7 +106,7 @@ namespace Microsoft.AspNetCore.Routing
 
             return dictionary;
         }
-        
+
         [Benchmark]
         public RouteValueDictionary ConditionalAdd_TryAdd()
         {

--- a/benchmarks/Microsoft.AspNetCore.Routing.Performance/RouteValueDictionaryBenchmark.cs
+++ b/benchmarks/Microsoft.AspNetCore.Routing.Performance/RouteValueDictionaryBenchmark.cs
@@ -85,7 +85,112 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         [Benchmark]
-        public RouteValueDictionary ConditionalAdd_ContainsKeyAdd()
+        public void TryAdd_Properties_AtCapacity_KeyExists()
+        {
+            var propertyValues = new RouteValueDictionary(new { action = "Index", controller = "Home", id = "17", area = "root" });
+            propertyValues.TryAdd("id", "15");
+        }
+
+        [Benchmark]
+        public void TryAdd_Properties_AtCapacity_KeyDoesNotExist()
+        {
+            var propertyValues = new RouteValueDictionary(new { action = "Index", controller = "Home", id = "17", area = "root" });
+            _propertyValues.TryAdd("name", "Service");
+        }
+
+        [Benchmark]
+        public void TryAdd_Properties_NotAtCapacity_KeyExists()
+        {
+            var propertyValues = new RouteValueDictionary(new { action = "Index", controller = "Home", id = "17" });
+            propertyValues.TryAdd("id", "15");
+        }
+
+        [Benchmark]
+        public void TryAdd_Properties_NotAtCapacity_KeyDoesNotExist()
+        {
+            var propertyValues = new RouteValueDictionary(new { action = "Index", controller = "Home", id = "17" });
+            _propertyValues.TryAdd("name", "Service");
+        }
+
+        [Benchmark]
+        public void TryAdd_Array_AtCapacity_KeyExists()
+        {
+            var arrayValues = new RouteValueDictionary
+                {
+                    { "action", "Index" },
+                    { "controller", "Home" },
+                    { "id", "17" },
+                    { "area", "root" }
+                };
+            arrayValues.TryAdd("id", "15");
+        }
+
+        [Benchmark]
+        public void TryAdd_Array_AtCapacity_KeyDoesNotExist()
+        {
+            var arrayValues = new RouteValueDictionary
+                {
+                    { "action", "Index" },
+                    { "controller", "Home" },
+                    { "id", "17" },
+                    { "area", "root" }
+                };
+            arrayValues.TryAdd("name", "Service");
+        }
+
+        [Benchmark]
+        public void TryAdd_Array_NotAtCapacity_KeyExists()
+        {
+            var arrayValues = new RouteValueDictionary
+                {
+                    { "action", "Index" },
+                    { "controller", "Home" },
+                    { "id", "17" }
+                };
+            arrayValues.TryAdd("id", "15");
+        }
+
+        [Benchmark]
+        public void TryAdd_Array_NotAtCapacity_KeyDoesNotExist()
+        {
+            var arrayValues = new RouteValueDictionary
+                {
+                    { "action", "Index" },
+                    { "controller", "Home" },
+                    { "id", "17" },
+                };
+            arrayValues.TryAdd("name", "Service");
+        }
+
+        [Benchmark]
+        public void ConditionalAdd_Array()
+        {
+            var arrayValues = new RouteValueDictionary()
+                {
+                    { "action", "Index" },
+                    { "controller", "Home" },
+                    { "id", "17" },
+                };
+
+            if (!arrayValues.ContainsKey("name"))
+            {
+                arrayValues.Add("name", "Service");
+            }
+        }
+
+        [Benchmark]
+        public void ConditionalAdd_Properties()
+        {
+            var propertyValues = new RouteValueDictionary(new { action = "Index", controller = "Home", id = "17" });
+
+            if (!propertyValues.ContainsKey("name"))
+            {
+                propertyValues.Add("name", "Service");
+            }
+        }
+
+        [Benchmark]
+        public RouteValueDictionary ConditionalAdd_ContainsKey_Array()
         {
             var dictionary = _arrayValues;
 

--- a/src/Microsoft.AspNetCore.Routing.Abstractions/RouteValueDictionary.cs
+++ b/src/Microsoft.AspNetCore.Routing.Abstractions/RouteValueDictionary.cs
@@ -311,6 +311,12 @@ namespace Microsoft.AspNetCore.Routing
                 ThrowArgumentNullExceptionForKey();
             }
 
+            return ContainsKeyCore(key);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool ContainsKeyCore(string key)
+        {
             if (_propertyStorage == null)
             {
                 return ContainsKeyArray(key);
@@ -472,12 +478,7 @@ namespace Microsoft.AspNetCore.Routing
                 ThrowArgumentNullExceptionForKey();
             }
 
-            // Since this is an attempt to write to the dictionary, just make it an array if it isn't. If the code
-            // path we're on event tries to write to the dictionary, it will likely get 'upgraded' at some point,
-            // so we do it here to keep the code size and complexity down.
-            EnsureCapacity(Count);
-
-            if (ContainsKeyArray(key))
+            if (ContainsKeyCore(key))
             {
                 return false;
             }

--- a/src/Microsoft.AspNetCore.Routing.Abstractions/RouteValueDictionary.cs
+++ b/src/Microsoft.AspNetCore.Routing.Abstractions/RouteValueDictionary.cs
@@ -127,6 +127,8 @@ namespace Microsoft.AspNetCore.Routing
 
             if (values is IEnumerable<KeyValuePair<string, object>> keyValueEnumerable)
             {
+                _arrayStorage = Array.Empty<KeyValuePair<string, object>>();
+
                 foreach (var kvp in keyValueEnumerable)
                 {
                     Add(kvp.Key, kvp.Value);
@@ -137,6 +139,8 @@ namespace Microsoft.AspNetCore.Routing
 
             if (values is IEnumerable<KeyValuePair<string, string>> stringValueEnumerable)
             {
+                _arrayStorage = Array.Empty<KeyValuePair<string, object>>();
+
                 foreach (var kvp in stringValueEnumerable)
                 {
                     Add(kvp.Key, kvp.Value);

--- a/test/Microsoft.AspNetCore.Mvc.Routing.Abstractions.Tests/RouteValueDictionaryTests.cs
+++ b/test/Microsoft.AspNetCore.Mvc.Routing.Abstractions.Tests/RouteValueDictionaryTests.cs
@@ -51,6 +51,8 @@ namespace Microsoft.AspNetCore.Routing.Tests
 
             // Assert
             Assert.Equal(other, dict);
+            Assert.Single(dict._arrayStorage);
+            Assert.Null(dict._propertyStorage);
 
             var storage = Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
             var otherStorage = Assert.IsType<KeyValuePair<string, object>[]>(other._arrayStorage);
@@ -68,6 +70,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
 
             // Assert
             Assert.Equal(other, dict);
+            Assert.Null(dict._arrayStorage);
 
             var storage = dict._propertyStorage;
             var otherStorage = other._propertyStorage;
@@ -259,6 +262,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
 
             // Assert
             Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
             Assert.Empty(dict);
         }
 
@@ -273,6 +277,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
 
             // Assert
             Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
             Assert.Empty(dict);
         }
 
@@ -287,6 +292,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
 
             // Assert
             Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
             Assert.Collection(
                 dict.OrderBy(kvp => kvp.Key),
                 kvp =>
@@ -314,6 +320,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
 
             // Assert
             Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
             Assert.Collection(
                 dict.OrderBy(kvp => kvp.Key),
                 kvp => { Assert.Equal("DerivedProperty", kvp.Key); Assert.Equal(5, kvp.Value); });
@@ -330,6 +337,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
 
             // Assert
             Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
             Assert.Empty(dict);
         }
 
@@ -918,6 +926,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
             // Assert
             Assert.Empty(dict);
             Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
         }
 
         [Fact]
@@ -932,6 +941,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
             // Assert
             Assert.Empty(dict);
             Assert.Null(dict._propertyStorage);
+            Assert.Empty(dict._arrayStorage);
         }
 
         [Fact]
@@ -949,10 +959,11 @@ namespace Microsoft.AspNetCore.Routing.Tests
             // Assert
             Assert.Empty(dict);
             Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
+            Assert.Null(dict._propertyStorage);
         }
 
         [Fact]
-        public void Contains_KeyValuePair_True()
+        public void Contains_ListStorage_KeyValuePair_True()
         {
             // Arrange
             var dict = new RouteValueDictionary()
@@ -971,7 +982,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
         }
 
         [Fact]
-        public void Contains_KeyValuePair_True_CaseInsensitive()
+        public void Contains_ListStory_KeyValuePair_True_CaseInsensitive()
         {
             // Arrange
             var dict = new RouteValueDictionary()
@@ -990,7 +1001,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
         }
 
         [Fact]
-        public void Contains_KeyValuePair_False()
+        public void Contains_ListStorage_KeyValuePair_False()
         {
             // Arrange
             var dict = new RouteValueDictionary()
@@ -1010,7 +1021,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
 
         // Value comparisons use the default equality comparer.
         [Fact]
-        public void Contains_KeyValuePair_False_ValueComparisonIsDefault()
+        public void Contains_ListStorage_KeyValuePair_False_ValueComparisonIsDefault()
         {
             // Arrange
             var dict = new RouteValueDictionary()
@@ -1026,6 +1037,87 @@ namespace Microsoft.AspNetCore.Routing.Tests
             // Assert
             Assert.False(result);
             Assert.IsType<KeyValuePair<string, object>[]>(dict._arrayStorage);
+        }
+
+        [Fact]
+        public void Contains_PropertyStorage_KeyValuePair_True()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary(new { key = "value" });
+
+            var input = new KeyValuePair<string, object>("key", "value");
+
+            // Act
+            var result = ((ICollection<KeyValuePair<string, object>>)dict).Contains(input);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
+            Assert.Collection(
+                dict,
+                kvp => Assert.Equal(new KeyValuePair<string, object>("key", "value"), kvp));
+        }
+
+        [Fact]
+        public void Contains_PropertyStory_KeyValuePair_True_CaseInsensitive()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary(new { key = "value" });
+
+            var input = new KeyValuePair<string, object>("KEY", "value");
+
+            // Act
+            var result = ((ICollection<KeyValuePair<string, object>>)dict).Contains(input);
+
+            // Assert
+            Assert.True(result);
+            Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
+            Assert.Collection(
+                dict,
+                kvp => Assert.Equal(new KeyValuePair<string, object>("key", "value"), kvp));
+        }
+
+        [Fact]
+        public void Contains_PropertyStorage_KeyValuePair_False()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary(new { key = "value" });
+
+            var input = new KeyValuePair<string, object>("other", "value");
+
+            // Act
+            var result = ((ICollection<KeyValuePair<string, object>>)dict).Contains(input);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
+            Assert.Collection(
+                dict,
+                kvp => Assert.Equal(new KeyValuePair<string, object>("key", "value"), kvp));
+        }
+
+        // Value comparisons use the default equality comparer.
+        [Fact]
+        public void Contains_PropertyStorage_KeyValuePair_False_ValueComparisonIsDefault()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary(new { key = "value" });
+
+            var input = new KeyValuePair<string, object>("key", "valUE");
+
+            // Act
+            var result = ((ICollection<KeyValuePair<string, object>>)dict).Contains(input);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
+            Assert.Collection(
+                dict,
+                kvp => Assert.Equal(new KeyValuePair<string, object>("key", "value"), kvp));
         }
 
         [Fact]
@@ -1066,6 +1158,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
             // Assert
             Assert.False(result);
             Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
         }
 
         [Fact]
@@ -1080,6 +1173,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
             // Assert
             Assert.True(result);
             Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
         }
 
         [Fact]
@@ -1094,6 +1188,7 @@ namespace Microsoft.AspNetCore.Routing.Tests
             // Assert
             Assert.True(result);
             Assert.NotNull(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
         }
 
         [Fact]
@@ -1635,9 +1730,28 @@ namespace Microsoft.AspNetCore.Routing.Tests
             Assert.True(result);
         }
 
-        // We always 'upgrade' if you are trying to write to the dictionary.
         [Fact]
-        public void TryAdd_ConvertsPropertyStorage_ToArrayStorage()
+        public void TryAdd_PropertyStorage_KeyDoesNotExist_ConvertsPropertyStorageToArrayStorage()
+        {
+            // Arrange
+            var dict = new RouteValueDictionary(new { key = "value", });
+
+            // Act
+            var result = dict.TryAdd("otherKey", "value");
+
+            // Assert
+            Assert.True(result);
+            Assert.Null(dict._propertyStorage);
+            Assert.Collection(
+                dict._arrayStorage,
+                kvp => Assert.Equal(new KeyValuePair<string, object>("key", "value"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("otherKey", "value"), kvp),
+                kvp => Assert.Equal(default, kvp),
+                kvp => Assert.Equal(default, kvp));
+        }
+
+        [Fact]
+        public void TryAdd_PropertyStory_KeyExist_DoesNotConvertPropertyStorageToArrayStorage()
         {
             // Arrange
             var dict = new RouteValueDictionary(new { key = "value", });
@@ -1647,13 +1761,11 @@ namespace Microsoft.AspNetCore.Routing.Tests
 
             // Assert
             Assert.False(result);
-            Assert.Null(dict._propertyStorage);
+            Assert.Null(dict._arrayStorage);
+            Assert.NotNull(dict._propertyStorage);
             Assert.Collection(
-                dict._arrayStorage,
-                kvp => Assert.Equal(new KeyValuePair<string, object>("key", "value"), kvp),
-                kvp => Assert.Equal(default, kvp),
-                kvp => Assert.Equal(default, kvp),
-                kvp => Assert.Equal(default, kvp));
+                dict,
+                kvp => Assert.Equal(new KeyValuePair<string, object>("key", "value"), kvp));
         }
 
         [Fact]


### PR DESCRIPTION
* Reduce allocations when **RouteValueDictionary** is initialized from another empty (array-based) **RouteValueDictionary**.
* When **RouteValueDictionary** is initialized from another non-empty array-based **RouteValueDictionary**, then only allocate an array that corresponds with the number of items in that **RouteValueDictionary** instead of the capacity.
* Refactor `ContainsKey(string key)` to use newly introduced `ContainsKeyArray(string key)` and `ContainsKeyProperties(string key)` methods that do not obtain the value of the key. This mostly affects the path where we're using property storage.
* Update `Add(string key, object value)` and `TryAdd(string key, object value)` to use `ContainsKeyArray(string key)` to check whether an entry with the specified key already exists.
* Improve performance of `TryAdd(string key, object value)` when backed by properties, and eliminate extra array allocation when number of properties is equal to capacity.

**Benchmarks:**

|                                          Method | Version    |      Mean |     Error |    StdDev |         Op/s |  Gen 0 | Allocated |
|------------------------------------------------ |-----------:|----------:|----------:|----------:|-------------:|-------:|----------:|
|                    ContainsKey_Properties_Found | release/2.2|  49.79 ns | 0.2453 ns | 0.1915 ns | 20,085,908.7 |      - |       0 B |
|                    ContainsKey_Properties_Found |  		 PR|  39.03 ns | 1.7731 ns | 1.9708 ns | 25,623,247.9 |      - |       0 B |
|                 ContainsKey_Properties_NotFound | release/2.2|  35.19 ns | 0.1114 ns | 0.0663 ns | 28,415,384.2 |      - |       0 B |
|                 ContainsKey_Properties_NotFound |  		 PR|  31.73 ns | 0.0754 ns | 0.0589 ns | 31,514,773.8 |      - |       0 B |
|          TryAdd_Properties_AtCapacity_KeyExists | release/2.2| 218.22 ns | 2.2617 ns | 2.1156 ns |  4,582,526.4 | 0.0024 |     208 B |
|          TryAdd_Properties_AtCapacity_KeyExists |  		 PR| 150.07 ns | 1.8355 ns | 1.7169 ns |  6,663,347.2 | 0.0014 |     120 B |
|    TryAdd_Properties_AtCapacity_KeyDoesNotExist | release/2.2| 151.90 ns | 1.2008 ns | 1.0645 ns |  6,583,092.7 | 0.0012 |     120 B |
|    TryAdd_Properties_AtCapacity_KeyDoesNotExist |  		 PR| 144.29 ns | 2.0227 ns | 1.8920 ns |  6,930,577.9 | 0.0014 |     120 B |
|       TryAdd_Properties_NotAtCapacity_KeyExists | release/2.2| 200.75 ns | 2.1600 ns | 2.0204 ns |  4,981,297.3 | 0.0021 |     200 B |
|       TryAdd_Properties_NotAtCapacity_KeyExists |  		 PR| 145.98 ns | 2.4794 ns | 2.3192 ns |  6,850,315.0 | 0.0010 |     112 B |
