### PR TITLE
Improve performance and reduce allocations in TemplateBinder ctor

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/Internal/ArrayBuilder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Internal/ArrayBuilder.cs
@@ -1,0 +1,169 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// LICENSING NOTE: This file is from the dotnet corefx repository.
+// 
+// See https://github.com/dotnet/corefx/blob/143df51926f2ad397fef9c9ca7ede88e2721e801/src/Common/src/System/Collections/Generic/ArrayBuilder.cs 
+
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Routing.Internal
+{
+    /// <summary>
+    /// Helper type for avoiding allocations while building arrays.
+    /// </summary>
+    /// <typeparam name="T">The element type.</typeparam>
+    internal struct ArrayBuilder<T>
+    {
+        private const int DefaultCapacity = 4;
+        private const int MaxCoreClrArrayLength = 0x7fefffff; // For byte arrays the limit is slightly larger
+
+        private T[] _array; // Starts out null, initialized on first Add.
+        private int _count; // Number of items into _array we're using.
+
+        /// <summary>
+        /// Initializes the <see cref="ArrayBuilder{T}"/> with a specified capacity.
+        /// </summary>
+        /// <param name="capacity">The capacity of the array to allocate.</param>
+        public ArrayBuilder(int capacity) : this()
+        {
+            Debug.Assert(capacity >= 0);
+            if (capacity > 0)
+            {
+                _array = new T[capacity];
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of items this instance can store without re-allocating,
+        /// or 0 if the backing array is <c>null</c>.
+        /// </summary>
+        public int Capacity => _array?.Length ?? 0;
+
+        /// <summary>Gets the current underlying array.</summary>
+        public T[] Buffer => _array;
+
+        /// <summary>
+        /// Gets the number of items in the array currently in use.
+        /// </summary>
+        public int Count => _count;
+
+        /// <summary>
+        /// Gets or sets the item at a certain index in the array.
+        /// </summary>
+        /// <param name="index">The index into the array.</param>
+        public T this[int index]
+        {
+            get
+            {
+                Debug.Assert(index >= 0 && index < _count);
+                return _array[index];
+            }
+        }
+
+        /// <summary>
+        /// Adds an item to the backing array, resizing it if necessary.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        public void Add(T item)
+        {
+            if (_count == Capacity)
+            {
+                EnsureCapacity(_count + 1);
+            }
+
+            UncheckedAdd(item);
+        }
+
+        /// <summary>
+        /// Gets the first item in this builder.
+        /// </summary>
+        public T First()
+        {
+            Debug.Assert(_count > 0);
+            return _array[0];
+        }
+
+        /// <summary>
+        /// Gets the last item in this builder.
+        /// </summary>
+        public T Last()
+        {
+            Debug.Assert(_count > 0);
+            return _array[_count - 1];
+        }
+
+        /// <summary>
+        /// Creates an array from the contents of this builder.
+        /// </summary>
+        /// <remarks>
+        /// Do not call this method twice on the same builder.
+        /// </remarks>
+        public T[] ToArray()
+        {
+            if (_count == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            Debug.Assert(_array != null); // Nonzero _count should imply this
+
+            T[] result = _array;
+            if (_count < result.Length)
+            {
+                // Avoid a bit of overhead (method call, some branches, extra codegen)
+                // which would be incurred by using Array.Resize
+                result = new T[_count];
+                Array.Copy(_array, 0, result, 0, _count);
+            }
+
+#if DEBUG
+            // Try to prevent callers from using the ArrayBuilder after ToArray, if _count != 0.
+            _count = -1;
+            _array = null;
+#endif
+
+            return result;
+        }
+
+        /// <summary>
+        /// Adds an item to the backing array, without checking if there is room.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <remarks>
+        /// Use this method if you know there is enough space in the <see cref="ArrayBuilder{T}"/>
+        /// for another item, and you are writing performance-sensitive code.
+        /// </remarks>
+        public void UncheckedAdd(T item)
+        {
+            Debug.Assert(_count < Capacity);
+
+            _array[_count++] = item;
+        }
+
+        private void EnsureCapacity(int minimum)
+        {
+            Debug.Assert(minimum > Capacity);
+
+            int capacity = Capacity;
+            int nextCapacity = capacity == 0 ? DefaultCapacity : 2 * capacity;
+
+            if ((uint)nextCapacity > (uint)MaxCoreClrArrayLength)
+            {
+                nextCapacity = Math.Max(capacity + 1, MaxCoreClrArrayLength);
+            }
+
+            nextCapacity = Math.Max(nextCapacity, minimum);
+
+            T[] next = new T[nextCapacity];
+            if (_count > 0)
+            {
+                Array.Copy(_array, 0, next, 0, _count);
+            }
+            _array = next;
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/TemplateBinder.cs
@@ -110,8 +110,13 @@ namespace Microsoft.AspNetCore.Routing.Template
             _slots = AssignSlots(_pattern.Parameters, _filters);
         }
 
-        private ((string parameterName, IRouteConstraint constraint)[] _constraints, (string parameterName, IOutboundParameterTransformer transformer)[] _parameterTransformers) ExtractParameterPolicies(IEnumerable<(string parameterName, IParameterPolicy policy)> parameterPolicies)
+        private ((string parameterName, IRouteConstraint constraint)[] constraints, (string parameterName, IOutboundParameterTransformer transformer)[] parameterTransformers) ExtractParameterPolicies(IEnumerable<(string parameterName, IParameterPolicy policy)> parameterPolicies)
         {
+            if (parameterPolicies == null)
+            {
+                return (Array.Empty<(string, IRouteConstraint)>(), Array.Empty<(string, IOutboundParameterTransformer)>());
+            }
+
             ArrayBuilder<(string, IRouteConstraint)> constraintsBuilder = new ArrayBuilder<(string, IRouteConstraint)>(0);
             ArrayBuilder<(string, IOutboundParameterTransformer)> transformersBuilder = new ArrayBuilder<(string, IOutboundParameterTransformer)>(0);
 


### PR DESCRIPTION
Improves performance and reduce allocations in TemplateBinder ctors:
* Avoids looping multiple times over parameter policies, and no longer uses Linq.
* Only filters out parameter names from defaults if there are defaults.
* When assigning slots, obtains parameter count only once.

Result:

|                                                Method |  Version |     Mean |    Error |   StdDev |        Op/s |  Gen 0 | Allocated |
|------------------------------------------------------ |:--------:|---------:|---------:|---------:|------------:|-------:|----------:|
|       ParametersAndDefaultsAndRequiredKeysAndPolicies | master   | 768.0 ns | 5.927 ns | 5.544 ns | 1,302,060.6 | 0.0105 |     968 B |
|       ParametersAndDefaultsAndRequiredKeysAndPolicies | PR - List\<T> |589.1 ns | 5.514 ns | 5.158 ns | 1,697,611.7 | 0.0095 |     840 B |
|       ParametersAndDefaultsAndRequiredKeysAndPolicies | PR - ArrayBuilder\<T> |565.9 ns | 1.284 ns | 1.072 ns | 1,767,084.3 | 0.0076 |     760 B |
|     ParametersAndNoDefaultsAndRequiredKeysAndPolicies | master   | 637.8 ns | 6.036 ns | 5.351 ns | 1,567,837.6 | 0.0095 |     824 B |
|     ParametersAndNoDefaultsAndRequiredKeysAndPolicies | PR - List\<T> |371.5 ns | 3.651 ns | 3.415 ns | 2,691,922.5 | 0.0076 |     696 B |
|     ParametersAndNoDefaultsAndRequiredKeysAndPolicies | PR - ArrayBuilder\<T> | 349.1 ns | 2.952 ns | 2.616 ns | 2,864,878.1 | 0.0072 |     616 B |
|     NoParametersAndDefaultsAndRequiredKeysAndPolicies | master   | 690.6 ns | 3.484 ns | 3.089 ns | 1,448,016.1 | 0.0105 |     984 B |
|     NoParametersAndDefaultsAndRequiredKeysAndPolicies | PR - List\<T> | 483.5 ns | 9.588 ns | 8.968 ns | 2,068,154.3 | 0.0095 |     856 B |
|     NoParametersAndDefaultsAndRequiredKeysAndPolicies | PR - ArrayBuilder\<T> | 458.9 ns | 3.747 ns | 3.505 ns | 2,179,081.6 | 0.0086 |     776 B |
| NoParametersAndNoDefaultsAndRequiredKeysAndNoPolicies | master   | 386.1 ns | 2.847 ns | 2.523 ns | 2,590,204.2 | 0.0048 |     424 B |
| NoParametersAndNoDefaultsAndRequiredKeysAndNoPolicies | PR - List\<T> | 316.5 ns | 3.476 ns | 3.252 ns | 3,159,387.1 | 0.0052 |     504 B |
| NoParametersAndNoDefaultsAndRequiredKeysAndNoPolicies | PR - ArrayBuilder\<T> | 300.6 ns | 2.025 ns | 1.795 ns | 3,326,396.0 | 0.0043 |     424 B |

Benchmark is available [here](https://gist.github.com/drieseng/23a663a5d7521b48b431cf41793016da).