### PR TITLE
Fix RouteValueAddressScheme to require metadata to match

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/RouteValuesAddressScheme.cs
+++ b/src/Microsoft.AspNetCore.Routing/RouteValuesAddressScheme.cs
@@ -125,6 +125,11 @@ namespace Microsoft.AspNetCore.Routing
                     continue;
                 }
 
+                if (endpoint.Metadata.GetMetadata<IRouteValuesAddressMetadata>() == null)
+                {
+                    continue;
+                }
+
                 if (endpoint.Metadata.GetMetadata<ISuppressLinkGenerationMetadata>()?.SuppressLinkGeneration == true)
                 {
                     continue;

--- a/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/DefaultLinkGeneratorTest.cs
@@ -321,7 +321,7 @@ namespace Microsoft.AspNetCore.Routing
         public void GetLink_ParameterTransformer()
         {
             // Arrange
-            var endpoint = EndpointFactory.CreateRouteEndpoint("{controller:upper-case}/{name}");
+            var endpoint = EndpointFactory.CreateRouteEndpoint("{controller:upper-case}/{name}", requiredValues: new { controller = "Home", name = "Test" });
 
             Action<IServiceCollection> configure = (s) =>
             {
@@ -344,7 +344,10 @@ namespace Microsoft.AspNetCore.Routing
         public void GetLink_ParameterTransformer_ForQueryString()
         {
             // Arrange
-            var endpoint = EndpointFactory.CreateRouteEndpoint("{controller:upper-case}/{name}", policies: new { c = new UpperCaseParameterTransform(), });
+            var endpoint = EndpointFactory.CreateRouteEndpoint(
+                "{controller:upper-case}/{name}",
+                requiredValues: new { controller = "Home", name = "Test", c = "hithere", },
+                policies: new { c = new UpperCaseParameterTransform(), });
 
             Action<IServiceCollection> configure = (s) =>
             {

--- a/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
@@ -228,6 +228,37 @@ namespace Microsoft.AspNetCore.Routing
         }
 
         [Fact]
+        public void FindEndpoints_LookedUpByCriteria_ExcludeEndpointWithoutRouteValuesAddressMetadata()
+        {
+            // Arrange
+            var endpoint1 = CreateEndpoint(
+                "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
+                defaults: new { zipCode = 3510 },
+                requiredValues: new { id = 7 },
+                routeName: "OrdersApi");
+            var endpoint2 = new RouteEndpoint(
+                c => null,
+                RoutePatternFactory.Parse("test"),
+                0,
+                EndpointMetadataCollection.Empty,
+                "Test endpoint");
+
+            var addressScheme = CreateAddressScheme(endpoint1, endpoint2);
+
+            // Act
+            var foundEndpoints = addressScheme.FindEndpoints(
+                new RouteValuesAddress
+                {
+                    ExplicitValues = new RouteValueDictionary(new { id = 7 }),
+                    AmbientValues = new RouteValueDictionary(new { zipCode = 3500 }),
+                }).ToList();
+
+            // Assert
+            Assert.DoesNotContain(endpoint2, foundEndpoints);
+            Assert.Contains(endpoint1, foundEndpoints);
+        }
+
+        [Fact]
         public void FindEndpoints_ReturnsEndpoint_WhenLookedUpByRouteName()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
@@ -146,13 +146,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
                 defaults: new { zipCode = 3510 },
-                requiredValues: new { id = 7 },
-                routeName: "OrdersApi");
+                requiredValues: new { id = 7 });
             var endpoint2 = CreateEndpoint(
                 "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
                 defaults: new { id = 12 },
-                requiredValues: new { zipCode = 3510 },
-                routeName: "OrdersApi");
+                requiredValues: new { zipCode = 3510 });
             var addressScheme = CreateAddressScheme(endpoint1, endpoint2);
 
             // Act
@@ -174,45 +172,11 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
                 defaults: new { zipCode = 3510 },
-                requiredValues: new { id = 7 },
-                routeName: "OrdersApi");
+                requiredValues: new { id = 7 });
             var endpoint2 = CreateEndpoint(
                 "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
-                defaults: new { id = 12 },
-                routeName: "OrdersApi");
+                defaults: new { id = 12 });
             var addressScheme = CreateAddressScheme(endpoint1, endpoint2);
-
-            // Act
-            var foundEndpoints = addressScheme.FindEndpoints(
-                new RouteValuesAddress
-                {
-                    ExplicitValues = new RouteValueDictionary(new { id = 13 }),
-                    AmbientValues = new RouteValueDictionary(new { zipCode = 3500 }),
-                });
-
-            // Assert
-            var actual = Assert.Single(foundEndpoints);
-            Assert.Same(endpoint2, actual);
-        }
-
-        [Fact]
-        public void FindEndpoints_LookedUpByCriteria_MultipleMatches()
-        {
-            // Arrange
-            var endpoint1 = CreateEndpoint(
-                "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
-                defaults: new { zipCode = 3510 },
-                requiredValues: new { id = 7 },
-                routeName: "OrdersApi");
-            var endpoint2 = CreateEndpoint(
-                "api/orders/{id}/{name?}/{urgent}/{zipCode}",
-                defaults: new { id = 12 },
-                routeName: "OrdersApi");
-            var endpoint3 = CreateEndpoint(
-                "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
-                defaults: new { id = 12 },
-                routeName: "OrdersApi");
-            var addressScheme = CreateAddressScheme(endpoint1, endpoint2, endpoint3);
 
             // Act
             var foundEndpoints = addressScheme.FindEndpoints(
@@ -223,8 +187,40 @@ namespace Microsoft.AspNetCore.Routing
                 });
 
             // Assert
-            Assert.Contains(endpoint1, foundEndpoints);
-            Assert.Contains(endpoint1, foundEndpoints);
+            var actual = Assert.Single(foundEndpoints);
+            Assert.Same(endpoint1, actual);
+        }
+
+        [Fact]
+        public void FindEndpoints_LookedUpByCriteria_MultipleMatches()
+        {
+            // Arrange
+            var endpoint1 = CreateEndpoint(
+                "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
+                defaults: new { zipCode = 3510 },
+                requiredValues: new { id = 7 });
+            var endpoint2 = CreateEndpoint(
+                "api/orders/{id}/{name?}/{urgent}/{zipCode}",
+                defaults: new { id = 12 },
+                requiredValues: new { id = 12 });
+            var endpoint3 = CreateEndpoint(
+                "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
+                defaults: new { id = 12 },
+                requiredValues: new { id = 12 });
+            var addressScheme = CreateAddressScheme(endpoint1, endpoint2, endpoint3);
+
+            // Act
+            var foundEndpoints = addressScheme.FindEndpoints(
+                new RouteValuesAddress
+                {
+                    ExplicitValues = new RouteValueDictionary(new { id = 12 }),
+                    AmbientValues = new RouteValueDictionary(new { zipCode = 3500 }),
+                });
+
+            // Assert
+            Assert.Collection(foundEndpoints,
+                e => Assert.Equal(endpoint3, e),
+                e => Assert.Equal(endpoint2, e));
         }
 
         [Fact]
@@ -234,8 +230,7 @@ namespace Microsoft.AspNetCore.Routing
             var endpoint1 = CreateEndpoint(
                 "api/orders/{id}/{name?}/{urgent=true}/{zipCode}",
                 defaults: new { zipCode = 3510 },
-                requiredValues: new { id = 7 },
-                routeName: "OrdersApi");
+                requiredValues: new { id = 7 });
             var endpoint2 = CreateEndpoint("test");
 
             var addressScheme = CreateAddressScheme(endpoint1, endpoint2);

--- a/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/RouteValuesAddressSchemeTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNetCore.Routing
         public void GetOutboundMatches_GetsNamedMatchesFor_EndpointsHaving_IRouteNameMetadata()
         {
             // Arrange
-            var endpoint1 = CreateEndpoint("/a");
+            var endpoint1 = CreateEndpoint("/a", routeName: "other");
             var endpoint2 = CreateEndpoint("/a", routeName: "named");
 
             // Act
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Routing
         public void GetOutboundMatches_GroupsMultipleEndpoints_WithSameName()
         {
             // Arrange
-            var endpoint1 = CreateEndpoint("/a");
+            var endpoint1 = CreateEndpoint("/a", routeName: "other");
             var endpoint2 = CreateEndpoint("/a", routeName: "named");
             var endpoint3 = CreateEndpoint("/b", routeName: "named");
 
@@ -59,7 +59,7 @@ namespace Microsoft.AspNetCore.Routing
         public void GetOutboundMatches_GroupsMultipleEndpoints_WithSameName_IgnoringCase()
         {
             // Arrange
-            var endpoint1 = CreateEndpoint("/a");
+            var endpoint1 = CreateEndpoint("/a", routeName: "other");
             var endpoint2 = CreateEndpoint("/a", routeName: "named");
             var endpoint3 = CreateEndpoint("/b", routeName: "NaMed");
 
@@ -80,7 +80,7 @@ namespace Microsoft.AspNetCore.Routing
         public void EndpointDataSource_ChangeCallback_Refreshes_OutboundMatches()
         {
             // Arrange 1
-            var endpoint1 = CreateEndpoint("/a");
+            var endpoint1 = CreateEndpoint("/a", requiredValues: new { });
             var dynamicDataSource = new DynamicEndpointDataSource(new[] { endpoint1 });
 
             // Act 1
@@ -93,21 +93,21 @@ namespace Microsoft.AspNetCore.Routing
             Assert.Same(endpoint1, actual);
 
             // Arrange 2
-            var endpoint2 = CreateEndpoint("/b");
+            var endpoint2 = CreateEndpoint("/b", requiredValues: new { });
 
             // Act 2
             // Trigger change
             dynamicDataSource.AddEndpoint(endpoint2);
 
             // Arrange 2
-            var endpoint3 = CreateEndpoint("/c");
+            var endpoint3 = CreateEndpoint("/c", requiredValues: new { });
 
             // Act 2
             // Trigger change
             dynamicDataSource.AddEndpoint(endpoint3);
 
             // Arrange 3
-            var endpoint4 = CreateEndpoint("/d");
+            var endpoint4 = CreateEndpoint("/d", requiredValues: new { });
 
             // Act 3
             // Trigger change
@@ -236,12 +236,7 @@ namespace Microsoft.AspNetCore.Routing
                 defaults: new { zipCode = 3510 },
                 requiredValues: new { id = 7 },
                 routeName: "OrdersApi");
-            var endpoint2 = new RouteEndpoint(
-                c => null,
-                RoutePatternFactory.Parse("test"),
-                0,
-                EndpointMetadataCollection.Empty,
-                "Test endpoint");
+            var endpoint2 = CreateEndpoint("test");
 
             var addressScheme = CreateAddressScheme(endpoint1, endpoint2);
 
@@ -333,7 +328,7 @@ namespace Microsoft.AspNetCore.Routing
             // Arrange
             var endpoint = EndpointFactory.CreateRouteEndpoint(
                 "/a",
-                metadata: new object[] { new SuppressLinkGenerationMetadata(), new EncourageLinkGenerationMetadata(), });
+                metadata: new object[] { new SuppressLinkGenerationMetadata(), new EncourageLinkGenerationMetadata(), new RouteValuesAddressMetadata(string.Empty), });
 
             // Act
             var addressScheme = CreateAddressScheme(endpoint);


### PR DESCRIPTION
Fixes https://github.com/aspnet/Routing/issues/906

Note that this issue also exists in release/2.2 but because all endpoints created by `MvcEndpointDataSource` have `IRouteValuesAddressMetadata`. This would be an issue if anyone creates their own data source. Should it be fixed on release/2.2 as well?