### PR TITLE
Add support for required values to RoutePattern

### DIFF
--- a/src/Microsoft.AspNetCore.Routing/DependencyInjection/RoutingServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Routing/DependencyInjection/RoutingServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Internal;
 using Microsoft.AspNetCore.Routing.Matching;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.Tree;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -85,6 +86,11 @@ namespace Microsoft.Extensions.DependencyInjection
             //
             services.TryAddSingleton<EndpointSelector, DefaultEndpointSelector>();
             services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, HttpMethodMatcherPolicy>());
+
+            //
+            // Misc infrastructure
+            // 
+            services.TryAddSingleton<RoutePatternTransformer, DefaultRoutePatternTransformer>();
 
             return services;
         }

--- a/src/Microsoft.AspNetCore.Routing/Internal/LinkGenerationDecisionTree.cs
+++ b/src/Microsoft.AspNetCore.Routing/Internal/LinkGenerationDecisionTree.cs
@@ -119,12 +119,7 @@ namespace Microsoft.AspNetCore.Routing.Internal
 
         private class OutboundMatchClassifier : IClassifier<OutboundMatch>
         {
-            public OutboundMatchClassifier()
-            {
-                ValueComparer = new RouteValueEqualityComparer();
-            }
-
-            public IEqualityComparer<object> ValueComparer { get; private set; }
+            public IEqualityComparer<object> ValueComparer => RouteValueEqualityComparer.Default;
 
             public IDictionary<string, DecisionCriterionValue> GetCriteria(OutboundMatch item)
             {

--- a/src/Microsoft.AspNetCore.Routing/Patterns/DefaultRoutePatternTransformer.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/DefaultRoutePatternTransformer.cs
@@ -1,0 +1,227 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Routing.Patterns
+{
+    internal class DefaultRoutePatternTransformer : RoutePatternTransformer
+    {
+        private readonly ParameterPolicyFactory _policyFactory;
+
+        public DefaultRoutePatternTransformer(ParameterPolicyFactory policyFactory)
+        {
+            if (policyFactory == null)
+            {
+                throw new ArgumentNullException(nameof(policyFactory));
+            }
+
+            _policyFactory = policyFactory;
+        }
+
+        public override RoutePattern SubstituteRequiredValues(RoutePattern original, object requiredValues)
+        {
+            if (original == null)
+            {
+                throw new ArgumentNullException(nameof(original));
+            }
+
+            return SubstituteRequiredValuesCore(original, new RouteValueDictionary(requiredValues));
+        }
+
+        private RoutePattern SubstituteRequiredValuesCore(RoutePattern original, RouteValueDictionary requiredValues)
+        {
+            // Process each required value in sequence. Bail if we find any rejection criteria. The goal
+            // of rejection is to avoid creating RoutePattern instances that can't *ever* match.
+            //
+            // If we succeed, then we need to create a new RoutePattern with the provided required values.
+            //
+            // Substitution can merge with existing RequiredValues already on the RoutePattern as long
+            // as all of the success criteria are still met at the end.
+            foreach (var kvp in requiredValues)
+            {
+                // There are three possible cases here:
+                // 1. Required value is null-ish
+                // 2. Required value corresponds to a parameter
+                // 3. Required value corresponds to a matching default value
+                //
+                // If none of these are true then we can reject this substitution.
+                RoutePatternParameterPart parameter;
+                if (RouteValueEqualityComparer.Default.Equals(kvp.Value, string.Empty))
+                {
+                    // 1. Required value is null-ish - check to make sure that this route doesn't have a
+                    // parameter or filter-like default.
+
+                    if (original.GetParameter(kvp.Key) != null)
+                    {
+                        // Fail: we can't 'require' that a parameter be null. In theory this would be possible
+                        // for an optional parameter, but that's not really in line with the usage of this feature
+                        // so we don't handle it.
+                        //
+                        // Ex: {controller=Home}/{action=Index}/{id?} - with required values: { controller = "" }
+                        return null;
+                    }
+                    else if (original.Defaults.TryGetValue(kvp.Key, out var defaultValue) &&
+                        !RouteValueEqualityComparer.Default.Equals(kvp.Value, defaultValue))
+                    {
+                        // Fail: this route has a non-parameter default that doesn't match.
+                        //
+                        // Ex: Admin/{controller=Home}/{action=Index}/{id?} defaults: { area = "Admin" } - with required values: { area = "" }
+                        return null;
+                    }
+
+                    // Success: (for this parameter at least)
+                    //
+                    // Ex: {controller=Home}/{action=Index}/{id?} - with required values: { area = "", ... }
+                    continue;
+                }
+                else if ((parameter = original.GetParameter(kvp.Key)) != null)
+                {
+                    // 2. Required value corresponds to a parameter - check to make sure that this value matches
+                    // any IRouteConstraint implementations.
+                    if (!MatchesConstraints(original, parameter, kvp.Key, requiredValues))
+                    {
+                        // Fail: this route has a constraint that failed.
+                        //
+                        // Ex: Admin/{controller:regex(Home|Login)}/{action=Index}/{id?} - with required values: { controller = "Store" }
+                        return null;
+                    }
+
+                    // Success: (for this parameter at least)
+                    //
+                    // Ex: {area}/{controller=Home}/{action=Index}/{id?} - with required values: { area = "", ... }
+                    continue;
+                }
+                else if (original.Defaults.TryGetValue(kvp.Key, out var defaultValue) &&
+                    RouteValueEqualityComparer.Default.Equals(kvp.Value, defaultValue))
+                {
+                    // 3. Required value corresponds to a matching default value - check to make sure that this value matches
+                    // any IRouteConstraint implementations. It's unlikely that this would happen in practice but it doesn't
+                    // hurt for us to check.
+                    if (!MatchesConstraints(original, parameter: null, kvp.Key, requiredValues))
+                    {
+                        // Fail: this route has a constraint that failed.
+                        //
+                        // Ex: 
+                        //  Admin/Home/{action=Index}/{id?} 
+                        //  defaults: { area = "Admin" }
+                        //  constraints: { area = "Blog" }
+                        //  with required values: { area = "Admin" }
+                        return null;
+                    }
+
+                    // Success: (for this parameter at least)
+                    //
+                    // Ex: Admin/{controller=Home}/{action=Index}/{id?} defaults: { area = "Admin" }- with required values: { area = "Admin", ... }
+                    continue;
+                }
+                else
+                {
+                    // Fail: this is a required value for a key that doesn't appear in the templates, or the route
+                    // pattern has a different default value for a non-parameter.
+                    //
+                    // Ex: Admin/{controller=Home}/{action=Index}/{id?} defaults: { area = "Admin" }- with required values: { area = "Blog", ... }
+                    // OR (less likely)
+                    // Ex: Admin/{controller=Home}/{action=Index}/{id?} with required values: { page = "/Index", ... }
+                    return null;
+                }
+            }
+
+            List<RoutePatternParameterPart> updatedParameters = null;
+            List<RoutePatternPathSegment> updatedSegments = null;
+            RouteValueDictionary updatedDefaults = null;
+
+            // So if we get here, we're ready to update the route pattern. We need to update two things:
+            // 1. Remove any default values that conflict with the required values.
+            // 2. Merge any existing required values
+            foreach (var kvp in requiredValues)
+            {
+                var parameter = original.GetParameter(kvp.Key);
+
+                // We only need to handle the case where the required value maps to a parameter. That's the only
+                // case where we allow a default and a required value to disagree, and we already validated the
+                // other cases.
+                if (parameter != null && 
+                    original.Defaults.TryGetValue(kvp.Key, out var defaultValue) && 
+                    !RouteValueEqualityComparer.Default.Equals(kvp.Value, defaultValue))
+                {
+                    if (updatedDefaults == null && updatedSegments == null && updatedParameters == null)
+                    {
+                        updatedDefaults = new RouteValueDictionary(original.Defaults);
+                        updatedSegments = new List<RoutePatternPathSegment>(original.PathSegments);
+                        updatedParameters = new List<RoutePatternParameterPart>(original.Parameters);
+                    }
+
+                    updatedDefaults.Remove(kvp.Key);
+                    RemoveParameterDefault(updatedSegments, updatedParameters, parameter);
+                }
+            }
+
+            foreach (var kvp in original.RequiredValues)
+            {
+                requiredValues.TryAdd(kvp.Key, kvp.Value);
+            }
+
+            return new RoutePattern(
+                original.RawText,
+                updatedDefaults ?? original.Defaults,
+                original.ParameterPolicies,
+                requiredValues,
+                updatedParameters ?? original.Parameters, 
+                updatedSegments ?? original.PathSegments);
+        }
+
+        private bool MatchesConstraints(RoutePattern pattern, RoutePatternParameterPart parameter, string key, RouteValueDictionary requiredValues)
+        {
+            if (pattern.ParameterPolicies.TryGetValue(key, out var policies))
+            {
+                for (var i = 0; i < policies.Count; i++)
+                {
+                    var policy = _policyFactory.Create(parameter, policies[i]);
+                    if (policy is IRouteConstraint constraint)
+                    {
+                        if (!constraint.Match(httpContext: null, NullRouter.Instance, key, requiredValues, RouteDirection.IncomingRequest))
+                        {
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private void RemoveParameterDefault(List<RoutePatternPathSegment> segments, List<RoutePatternParameterPart> parameters, RoutePatternParameterPart parameter)
+        {
+            // We know that a parameter can only appear once, so we only need to rewrite one segment and one parameter.
+            for (var i = 0; i < segments.Count; i++)
+            {
+                var segment = segments[i];
+                for (var j = 0; j < segment.Parts.Count; j++)
+                {
+                    if (object.ReferenceEquals(parameter, segment.Parts[j]))
+                    {
+                        // Found it!
+                        var updatedParameter = RoutePatternFactory.ParameterPart(parameter.Name, @default: null, parameter.ParameterKind, parameter.ParameterPolicies);
+
+                        var updatedParts = new List<RoutePatternPart>(segment.Parts);
+                        updatedParts[j] = updatedParameter;
+                        segments[i] = RoutePatternFactory.Segment(updatedParts);
+
+                        for (var k = 0; k < parameters.Count; k++)
+                        {
+                            if (ReferenceEquals(parameter, parameters[k]))
+                            {
+                                parameters[k] = updatedParameter;
+                                break;
+                            }
+                        }
+
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePattern.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePattern.cs
@@ -23,17 +23,20 @@ namespace Microsoft.AspNetCore.Routing.Patterns
             string rawText,
             IReadOnlyDictionary<string, object> defaults,
             IReadOnlyDictionary<string, IReadOnlyList<RoutePatternParameterPolicyReference>> parameterPolicies,
+            IReadOnlyDictionary<string, object> requiredValues,
             IReadOnlyList<RoutePatternParameterPart> parameters,
             IReadOnlyList<RoutePatternPathSegment> pathSegments)
         {
             Debug.Assert(defaults != null);
             Debug.Assert(parameterPolicies != null);
             Debug.Assert(parameters != null);
+            Debug.Assert(requiredValues != null);
             Debug.Assert(pathSegments != null);
 
             RawText = rawText;
             Defaults = defaults;
             ParameterPolicies = parameterPolicies;
+            RequiredValues = requiredValues;
             Parameters = parameters;
             PathSegments = pathSegments;
 
@@ -52,6 +55,29 @@ namespace Microsoft.AspNetCore.Routing.Patterns
         /// The keys of <see cref="ParameterPolicies"/> are the route parameter names.
         /// </summary>
         public IReadOnlyDictionary<string, IReadOnlyList<RoutePatternParameterPolicyReference>> ParameterPolicies { get; }
+
+        /// <summary>
+        /// Gets a collection of route values that must be provided for this route pattern to be considered
+        /// applicable.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// <see cref="RequiredValues"/> allows a framework to substitute route values into a parameterized template
+        /// so that the same route template specification can be used to create multiple route patterns.
+        /// <example>
+        /// This example shows how a route template can be used with required values to substitute known
+        /// route values for parameters.
+        /// <code>
+        /// Route Template: "{controller=Home}/{action=Index}/{id?}"
+        /// Route Values: { controller = "Store", action = "Index" }
+        /// </code>
+        /// 
+        /// A route pattern produced in this way will match and generate URL paths like: <c>/Store</c>, 
+        /// <c>/Store/Index</c>, and <c>/Store/Index/17</c>.
+        /// </example>
+        /// </para>
+        /// </remarks>
+        public IReadOnlyDictionary<string, object> RequiredValues { get; }
 
         /// <summary>
         /// Gets the precedence value of the route pattern for URL matching.

--- a/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternTransformer.cs
+++ b/src/Microsoft.AspNetCore.Routing/Patterns/RoutePatternTransformer.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Routing.Patterns
+{
+    /// <summary>
+    /// A singleton service that provides transformations on <see cref="RoutePattern"/>.
+    /// </summary>
+    public abstract class RoutePatternTransformer
+    {
+        /// <summary>
+        /// Attempts to substitute the provided <paramref name="requiredValues"/> into the provided
+        /// <paramref name="original"/>.
+        /// </summary>
+        /// <param name="original">The original <see cref="RoutePattern"/>.</param>
+        /// <param name="requiredValues">The required values to substitute.</param>
+        /// <returns>
+        /// A new <see cref="RoutePattern"/> if substitution succeeds, otherwise <c>null</c>.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// Substituting required values into a route pattern is intended for us with a general-purpose
+        /// parameterize route specification that can match many logical endpoints. Calling 
+        /// <see cref="SubstituteRequiredValues(RoutePattern, object)"/> can produce a derived route pattern
+        /// for each set of route values that corresponds to an endpoint.
+        /// </para>
+        /// <para>
+        /// The substitution process considers default values and <see cref="IRouteConstraint"/> implementations
+        /// when examining a required value. <see cref="SubstituteRequiredValues(RoutePattern, object)"/> will
+        /// return <c>null</c> if any required value cannot be substituted.
+        /// </para>
+        /// </remarks>
+        public abstract RoutePattern SubstituteRequiredValues(RoutePattern original, object requiredValues);
+    }
+}

--- a/src/Microsoft.AspNetCore.Routing/RouteValueEqualityComparer.cs
+++ b/src/Microsoft.AspNetCore.Routing/RouteValueEqualityComparer.cs
@@ -20,6 +20,8 @@ namespace Microsoft.AspNetCore.Routing
     /// </remarks>
     public class RouteValueEqualityComparer : IEqualityComparer<object>
     {
+        public static readonly RouteValueEqualityComparer Default = new RouteValueEqualityComparer();
+
         /// <inheritdoc />
         public new bool Equals(object x, object y)
         {

--- a/src/Microsoft.AspNetCore.Routing/Template/RouteTemplate.cs
+++ b/src/Microsoft.AspNetCore.Routing/Template/RouteTemplate.cs
@@ -16,6 +16,13 @@ namespace Microsoft.AspNetCore.Routing.Template
 
         public RouteTemplate(RoutePattern other)
         {
+            if (other == null)
+            {
+                throw new ArgumentNullException(nameof(other));
+            }
+
+            // RequiredValues will be ignored. RouteTemplate doesn't support them.
+
             TemplateText = other.RawText;
             Segments = new List<TemplateSegment>(other.PathSegments.Select(p => new TemplateSegment(p)));
             Parameters = new List<TemplatePart>();

--- a/test/Microsoft.AspNetCore.Routing.DecisionTree.Sources.Tests/DecisionTreeBuilderTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.DecisionTree.Sources.Tests/DecisionTreeBuilderTest.cs
@@ -207,13 +207,7 @@ namespace Microsoft.AspNetCore.Routing.DecisionTree
 
         private class ItemClassifier : IClassifier<Item>
         {
-            public IEqualityComparer<object> ValueComparer
-            {
-                get
-                {
-                    return new RouteValueEqualityComparer();
-                }
-            }
+            public IEqualityComparer<object> ValueComparer => RouteValueEqualityComparer.Default;
 
             public IDictionary<string, DecisionCriterionValue> GetCriteria(Item item)
             {

--- a/test/Microsoft.AspNetCore.Routing.Tests/Patterns/DefaultRoutePatternTransformerTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Patterns/DefaultRoutePatternTransformerTest.cs
@@ -1,0 +1,339 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Routing.Patterns
+{
+    public class DefaultRoutePatternTransformerTest
+    {
+        public DefaultRoutePatternTransformerTest()
+        {
+            var services = new ServiceCollection();
+            services.AddRouting();
+            services.AddOptions();
+            Transformer = services.BuildServiceProvider().GetRequiredService<RoutePatternTransformer>();
+        }
+
+        public RoutePatternTransformer Transformer { get; }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanAcceptNullForAnyKey()
+        {
+            // Arrange
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new { };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { a = (string)null, b = "", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("a", null), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("b", string.Empty), kvp));
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_RejectsNullForParameter()
+        {
+            // Arrange
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new { };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = string.Empty, };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_RejectsNullForOutOfLineDefault()
+        {
+            // Arrange
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new { area = "Admin" };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { area = string.Empty, };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanAcceptValueForParameter()
+        {
+            // Arrange
+            var template = "{controller}/{action}/{id?}";
+            var defaults = new { };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("action", "Index"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanAcceptValueForParameter_WithSameDefault()
+        {
+            // Arrange
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new { };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("action", "Index"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
+
+            // We should not need to rewrite anything in this case.
+            Assert.Same(actual.Defaults, original.Defaults);
+            Assert.Same(actual.Parameters, original.Parameters);
+            Assert.Same(actual.PathSegments, original.PathSegments);
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanAcceptValueForParameter_WithDifferentDefault()
+        {
+            // Arrange
+            var template = "{controller=Blog}/{action=ReadPost}/{id?}";
+            var defaults = new { area = "Admin", };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { area = "Admin", controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("action", "Index"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("area", "Admin"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
+
+            // We should not need to rewrite anything in this case.
+            Assert.NotSame(actual.Defaults, original.Defaults);
+            Assert.NotSame(actual.Parameters, original.Parameters);
+            Assert.NotSame(actual.PathSegments, original.PathSegments);
+
+            // other defaults were wiped out
+            Assert.Equal(new KeyValuePair<string, object>("area", "Admin"), Assert.Single(actual.Defaults));
+            Assert.Null(actual.GetParameter("controller").Default);
+            Assert.False(actual.Defaults.ContainsKey("controller"));
+            Assert.Null(actual.GetParameter("action").Default);
+            Assert.False(actual.Defaults.ContainsKey("action"));
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanAcceptValueForParameter_WithMatchingConstraint()
+        {
+            // Arrange
+            var template = "{controller}/{action}/{id?}";
+            var defaults = new { };
+            var policies = new { controller = "Home", action = new RegexRouteConstraint("Index"), };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("action", "Index"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanRejectValueForParameter_WithNonMatchingConstraint()
+        {
+            // Arrange
+            var template = "{controller}/{action}/{id?}";
+            var defaults = new { };
+            var policies = new { controller = "Home", action = new RegexRouteConstraint("Index"), };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = "Blog", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanAcceptValueForDefault_WithSameValue()
+        {
+            // Arrange
+            var template = "Home/Index/{id?}";
+            var defaults = new { controller = "Home", action = "Index", };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("action", "Index"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanRejectValueForDefault_WithDifferentValue()
+        {
+            // Arrange
+            var template = "Home/Index/{id?}";
+            var defaults = new { controller = "Home", action = "Index", };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = "Blog", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanAcceptValueForDefault_WithSameValue_Null()
+        {
+            // Arrange
+            var template = "Home/Index/{id?}";
+            var defaults = new { controller = (string)null, action = "", };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = string.Empty, action = (string)null, };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("action", null), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("controller", ""), kvp));
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanAcceptValueForDefault_WithSameValue_WithMatchingConstraint()
+        {
+            // Arrange
+            var template = "Home/Index/{id?}";
+            var defaults = new { controller = "Home", action = "Index", };
+            var policies = new { controller = "Home", };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("action", "Index"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanRejectValueForDefault_WithSameValue_WithNonMatchingConstraint()
+        {
+            // Arrange
+            var template = "Home/Index/{id?}";
+            var defaults = new { controller = "Home", action = "Index", };
+            var policies = new { controller = "Home", };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies);
+
+            var requiredValues = new { controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("action", "Index"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
+        }
+
+        [Fact]
+        public void SubstituteRequiredValues_CanMergeExistingRequiredValues()
+        {
+            // Arrange
+            var template = "Home/Index/{id?}";
+            var defaults = new { area = "Admin", controller = "Home", action = "Index", };
+            var policies = new { };
+
+            var original = RoutePatternFactory.Parse(template, defaults, policies, new { area = "Admin", controller = "Home", });
+
+            var requiredValues = new { controller = "Home", action = "Index", };
+
+            // Act
+            var actual = Transformer.SubstituteRequiredValues(original, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                actual.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("action", "Index"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("area", "Admin"), kvp),
+                kvp => Assert.Equal(new KeyValuePair<string, object>("controller", "Home"), kvp));
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.Routing.Tests/Patterns/RoutePatternFactoryTest.cs
+++ b/test/Microsoft.AspNetCore.Routing.Tests/Patterns/RoutePatternFactoryTest.cs
@@ -442,6 +442,89 @@ namespace Microsoft.AspNetCore.Routing.Patterns
         }
 
         [Fact]
+        public void Parse_WithRequiredValues()
+        {
+            // Arrange
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new { area = "Admin", };
+            var policies = new { };
+            var requiredValues = new { area = "Admin", controller = "Store", action = "Index", };
+
+            // Act
+            var action = RoutePatternFactory.Parse(template, defaults, policies, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                action.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => { Assert.Equal("action", kvp.Key); Assert.Equal("Index", kvp.Value); },
+                kvp => { Assert.Equal("area", kvp.Key); Assert.Equal("Admin", kvp.Value); },
+                kvp => { Assert.Equal("controller", kvp.Key); Assert.Equal("Store", kvp.Value); });
+        }
+
+        [Fact]
+        public void Parse_WithRequiredValues_AllowsNullRequiredValue()
+        {
+            // Arrange
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new { };
+            var policies = new { };
+            var requiredValues = new { area = (string)null, controller = "Store", action = "Index", };
+
+            // Act
+            var action = RoutePatternFactory.Parse(template, defaults, policies, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                action.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => { Assert.Equal("action", kvp.Key); Assert.Equal("Index", kvp.Value); },
+                kvp => { Assert.Equal("area", kvp.Key); Assert.Null(kvp.Value); },
+                kvp => { Assert.Equal("controller", kvp.Key); Assert.Equal("Store", kvp.Value); });
+        }
+
+        [Fact]
+        public void Parse_WithRequiredValues_AllowsEmptyRequiredValue()
+        {
+            // Arrange
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new { };
+            var policies = new { };
+            var requiredValues = new { area = "", controller = "Store", action = "Index", };
+
+            // Act
+            var action = RoutePatternFactory.Parse(template, defaults, policies, requiredValues);
+
+            // Assert
+            Assert.Collection(
+                action.RequiredValues.OrderBy(kvp => kvp.Key),
+                kvp => { Assert.Equal("action", kvp.Key); Assert.Equal("Index", kvp.Value); },
+                kvp => { Assert.Equal("area", kvp.Key); Assert.Equal("", kvp.Value); },
+                kvp => { Assert.Equal("controller", kvp.Key); Assert.Equal("Store", kvp.Value); });
+        }
+
+        [Fact]
+        public void Parse_WithRequiredValues_ThrowsForNonParameterNonDefault()
+        {
+            // Arrange
+            var template = "{controller=Home}/{action=Index}/{id?}";
+            var defaults = new { };
+            var policies = new { };
+            var requiredValues = new { area = "Admin", controller = "Store", action = "Index", };
+
+            // Act
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var action = RoutePatternFactory.Parse(template, defaults, policies, requiredValues);
+            });
+
+            // Assert
+            Assert.Equal(
+                "No corresponding parameter or default value could be found for the required value " +
+                "'area=Admin'. A non-null required value must correspond to a route parameter or the " +
+                "route pattern must have a matching default value.", 
+                exception.Message);
+        }
+        
+        [Fact]
         public void ParameterPart_ParameterNameAndDefaultAndParameterKindAndArrayOfParameterPolicies_ShouldMakeCopyOfParameterPolicies()
         {
             // Arrange (going through hoops to get an array of RoutePatternParameterPolicyReference)


### PR DESCRIPTION
This change adds first class support for what MVC does to substitute route values into templates. Rather than munging strings, I chose to introduce required values as a fundamental concept.

The idea is that a *conventional-route-style* template could we written once, and then *expanded* for every action and controller that exists. Making this first class in routing moves the complexity into the right place, and will reduce the number of endpoints produced for a conventionally routed application significantly.

Still left to do here is to add support to `DfaMatcher` to process the required values. Then we should probably obsolete `IRouteValuesAddressMetadata` since it's now first class. 